### PR TITLE
Including `README` in the heading is not necessary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Four Keys README 
+# Four Keys
 
 
 # Background


### PR DESCRIPTION
The file is named `README.md` the first heading does not need to reiterate that this is the README.

Signed-off-by: Nathen Harvey <nathenharvey@google.com>