### PR TITLE
Gitlab Integration

### DIFF
--- a/bq_workers/gitlab_parser/Dockerfile
+++ b/bq_workers/gitlab_parser/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Use the official Python image.
+# https://hub.docker.com/_/python
+FROM python:3.7
+
+# Allow statements and log messages to immediately appear in the Cloud Run logs
+ENV PYTHONUNBUFFERED True
+
+# Copy application dependency manifests to the container image.
+# Copying this separately prevents re-running pip install on every code change.
+COPY requirements.txt .
+
+# Install production dependencies.
+RUN pip install -r requirements.txt
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . .
+
+# Run the web service on container startup.
+# Use gunicorn webserver with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/bq_workers/gitlab_parser/cloudbuild.yaml
+++ b/bq_workers/gitlab_parser/cloudbuild.yaml
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- # Build new-source worker image
+  name: gcr.io/cloud-builders/docker:latest
+  args: ['build', 
+         '--tag=gcr.io/$PROJECT_ID/gitlab-worker:${_TAG}', '.']
+  id: build
+
+- # Push the container image to Container Registry
+  name: gcr.io/cloud-builders/docker
+  args: ['push', 'gcr.io/$PROJECT_ID/gitlab-worker:${_TAG}']
+  waitFor: build
+  id: push
+
+- # Deploy to Cloud Run
+  name: gcr.io/cloud-builders/gcloud
+  args: ['run', 'deploy', 'gitlab-worker',
+         '--image', 'gcr.io/$PROJECT_ID/gitlab-worker:${_TAG}',
+         '--region', '${_REGION}',
+         '--platform', 'managed'
+  ]
+  id: deploy
+  waitFor: push
+
+images: [
+  'gcr.io/$PROJECT_ID/gitlab-worker'
+]

--- a/bq_workers/gitlab_parser/main.py
+++ b/bq_workers/gitlab_parser/main.py
@@ -51,7 +51,7 @@ def index():
         if "headers" in attr:
             headers = json.loads(attr["headers"])
 
-            # Process Github Events
+            # Process Gitlab Events
             if "X-Gitlab-Event" in headers:
                 event = process_gitlab_event(headers, msg)
 

--- a/bq_workers/gitlab_parser/main.py
+++ b/bq_workers/gitlab_parser/main.py
@@ -1,0 +1,128 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import os
+import json
+import sys
+
+import shared
+
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+@app.route("/", methods=["POST"])
+def index():
+    """
+    Receives messages from a push subscription from Pub/Sub.
+    Parses the message, and inserts it into BigQuery.
+    """
+    event = None
+    envelope = request.get_json()
+
+    # Check that data has been posted
+    if not envelope:
+        raise Exception("Expecting JSON payload")
+    # Check that message is a valid pub/sub message
+    if "message" not in envelope:
+        raise Exception("Not a valid Pub/Sub Message")
+    msg = envelope["message"]
+
+    if "attributes" not in msg:
+        raise Exception("Missing pubsub attributes")
+
+    try:
+        attr = msg["attributes"]
+
+        # Header Event info
+        if "headers" in attr:
+            headers = json.loads(attr["headers"])
+
+            # Process Github Events
+            if "X-Gitlab-Event" in headers:
+                event = process_gitlab_event(headers, msg)
+
+        shared.insert_row_into_bigquery(event)
+
+    except Exception as e:
+        entry = {
+                "severity": "WARNING",
+                "msg": "Data not saved to BigQuery",
+                "errors": str(e),
+                "json_payload": envelope
+            }
+        print(json.dumps(entry))
+
+    return "", 204
+
+
+def process_gitlab_event(headers, msg):
+    # Unique hash for the event
+    signature = shared.create_unique_id(msg)
+    source = "gitlab"
+
+    if "Mock" in headers:
+        source += "mock"
+
+    types = {"push", "merge_request", "note", "tag_push", "issue", "pipeline", "job"}
+
+    metadata = json.loads(base64.b64decode(msg["data"]).decode("utf-8").strip())
+    print(metadata)
+    event_type = metadata["object_kind"]
+
+    if event_type not in types:
+        raise Exception("Unsupported Gitlab event: '%s'" % event_type)
+
+    if event_type in ("push", "tag_push"):
+        e_id = metadata["checkout_sha"]
+        for commit in metadata["commits"]:
+            if commit["id"] == e_id:
+                time_created = commit["timestamp"]
+
+    if event_type in ("merge_request", "note", "issue", "pipeline"):
+        event_object = metadata["object_attributes"]
+        e_id = event_object["id"]
+        time_created = (
+            event_object.get("updated_at") or 
+            event_object.get("finished_at") or
+            event_object.get("created_at"))
+
+    if event_type in ("job"):
+        e_id = metadata["build_id"]
+        time_created = (
+            event_object.get("finished_at") or 
+            event_object.get("started_at"))
+
+    gitlab_event = {
+        "event_type": event_type,
+        "id": e_id,
+        "metadata": json.dumps(metadata),
+        # If time_created not supplied by event, default to pub/sub publishTime
+        "time_created": time_created or msg["publishTime"], 
+        "signature": signature,
+        "msg_id": msg["message_id"],
+        "source": source,
+    }
+
+    return gitlab_event
+
+
+if __name__ == "__main__":
+    PORT = int(os.getenv("PORT")) if os.getenv("PORT") else 8080
+
+    # This is used when running locally. Gunicorn is used to run the
+    # application on Cloud Run. See entrypoint in Dockerfile.
+    app.run(host="127.0.0.1", port=PORT, debug=True)

--- a/bq_workers/gitlab_parser/main_test.py
+++ b/bq_workers/gitlab_parser/main_test.py
@@ -1,0 +1,89 @@
+# Copyright 2020 Google, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import json
+
+import main
+import shared
+
+import mock
+import pytest
+
+
+@pytest.fixture
+def client():
+    main.app.testing = True
+    return main.app.test_client()
+
+
+def test_not_json(client):
+    with pytest.raises(Exception) as e:
+        client.post("/", data="foo")
+
+    assert "Expecting JSON payload" in str(e.value)
+
+
+def test_not_pubsub_message(client):
+    with pytest.raises(Exception) as e:
+        client.post(
+            "/",
+            data=json.dumps({"foo": "bar"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert "Not a valid Pub/Sub Message" in str(e.value)
+
+
+def test_missing_msg_attributes(client):
+    with pytest.raises(Exception) as e:
+        client.post(
+            "/",
+            data=json.dumps({"message": "bar"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert "Missing pubsub attributes" in str(e.value)
+
+
+def test_new_source_event_processed(client):
+    data = json.dumps({"foo": "bar"}).encode("utf-8")
+    pubsub_msg = {
+        "message": {
+            "data": base64.b64encode(data).decode("utf-8"),
+            "attributes": {"foo": "bar"},
+            "message_id": "foobar",
+        },
+    }
+
+    event = {
+        "event_type": "event_type",
+        "id": "e_id",
+        "metadata": '{"foo": "bar"}',
+        "time_created": 0,
+        "signature": "signature",
+        "msg_id": "foobar",
+        "source": "source",
+    }
+
+    shared.insert_row_into_bigquery = mock.MagicMock()
+
+    r = client.post(
+        "/",
+        data=json.dumps(pubsub_msg),
+        headers={"Content-Type": "application/json"},
+    )
+
+    shared.insert_row_into_bigquery.assert_called_with(event)
+    assert r.status_code == 204

--- a/bq_workers/gitlab_parser/requirements.txt
+++ b/bq_workers/gitlab_parser/requirements.txt
@@ -1,0 +1,6 @@
+Flask==1.1.1
+pytest==5.3.0; python_version > "3.0"
+pytest==4.6.6; python_version < "3.0"
+gunicorn==19.9.0
+google-cloud-bigquery==1.23.1
+git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared

--- a/data_generator/github_data.py
+++ b/data_generator/github_data.py
@@ -24,7 +24,6 @@ import time
 from hashlib import sha1
 from urllib.request import Request, urlopen
 
-
 def make_changes(num_changes):
     changes = []
     # One week ago
@@ -66,7 +65,7 @@ def make_issue(root_cause):
 def send_mock_github_events(event_type, data):
     webhook_url = os.environ.get("WEBHOOK")
     data = json.dumps(data, default=str).encode()
-    secret = os.environ.get("GITHUB_SECRET").encode()
+    secret = os.environ.get("SECRET").encode()
     signature = hmac.new(secret, data, sha1)
 
     request = Request(webhook_url, data)

--- a/data_generator/gitlab_data.py
+++ b/data_generator/gitlab_data.py
@@ -1,0 +1,134 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import datetime
+import hmac
+import json
+import random
+import os
+import secrets
+import time
+
+from hashlib import sha1
+from urllib.request import Request, urlopen
+
+def make_changes(num_changes):
+    changes = []
+    # One week ago
+    max_time = time.time() - 604800
+    head_commit = None
+
+    for x in range(num_changes):
+        change_id = secrets.token_hex(20)
+        unix_timestamp = time.time() - random.randrange(0, 604800)
+        change = {
+            "id": change_id,
+            "timestamp": datetime.datetime.fromtimestamp(unix_timestamp),
+        }
+
+        if unix_timestamp > max_time:
+            max_time = unix_timestamp
+            head_commit = change
+
+        changes.append(change)
+
+    event = {"object_kind": "push", 
+             "checkout_sha": head_commit["id"], 
+             "commits": changes}
+    return event
+
+
+def make_issue(changes):
+    checkout_sha = changes["checkout_sha"]
+    for c in changes["commits"]:
+        if c["id"] == checkout_sha:
+            issue = {
+                "object_kind": "issue",
+                "object_attributes": {
+                    "created_at": c["timestamp"],
+                    "updated_at": datetime.datetime.now(),
+                    "closed_at": datetime.datetime.now(),
+                    "id": random.randrange(0, 1000),
+                    "labels": [{"title": "Incident"}],
+                    "description": "root cause: %s" % c["id"],
+                }
+            }
+    return issue
+
+
+def send_mock_gitlab_events(event_type, data):
+    webhook_url = os.environ.get("WEBHOOK")
+    data = json.dumps(data, default=str).encode()
+    secret = os.environ.get("SECRET")
+
+    request = Request(webhook_url, data)
+    request.add_header("X-Gitlab-Event", event_type)
+    request.add_header("X-Gitlab-Token", secret)
+    request.add_header("Content-Type", "application/json")
+    request.add_header("Mock", True)
+
+    response = urlopen(request)
+
+    if response.getcode() == 204:
+        return 1
+    else:
+        return 0
+
+
+def create_pipeline_event(changes):
+    checkout_sha = changes["checkout_sha"]
+    for c in changes["commits"]:
+        if c["id"] == checkout_sha:
+            pipeline = {
+                "object_kind": "pipeline",
+                "object_attributes": {
+                    "created_at": c["timestamp"],
+                    "id": random.randrange(0, 1000),
+                    "status": "success"
+                },
+                "commit": c,
+            }
+    return pipeline
+
+
+def generate_data():
+    num_success = 0
+    changes = make_changes(2)
+
+    # Send individual changes data
+    for c in changes["commits"]:
+        curr_change = {"object_kind": "push", "checkout_sha": c['id'], "commits": [c]}
+        num_success += send_mock_gitlab_events("push", curr_change)
+
+    # Send fully associated push event
+    num_success += send_mock_gitlab_events("push", changes)
+
+    # Make and send a deployment
+    pipeline = create_pipeline_event(changes)
+    num_success += send_mock_gitlab_events("pipeline", pipeline)
+
+    # # 15% of deployments create incidents
+    x = random.randrange(0, 100)
+    if x < 15:
+        issue = make_issue(changes)
+        num_success += send_mock_gitlab_events("issue", issue)
+
+    return num_success
+
+num_success = 0
+for x in range(100):
+    num_success += generate_data()
+    
+print(f"{num_success} changes successfully sent to event-handler")

--- a/event_handler/sources.py
+++ b/event_handler/sources.py
@@ -83,13 +83,13 @@ def get_source(headers):
     """
     Gets the source from the User-Agent header
     """
+    if "X-Gitlab-Event" in headers:
+        return "Gitlab"
+
     if "User-Agent" in headers:
         if "/" in headers["User-Agent"]:
             return headers["User-Agent"].split("/")[0]
         return headers["User-Agent"]
-
-    if "X-Gitlab-Event" in headers:
-        return "Gitlab"
 
     return None
 

--- a/queries/changes.sql
+++ b/queries/changes.sql
@@ -1,7 +1,9 @@
+# Changes Table
 SELECT 
-id as change_id, 
-time_created, 
+source,
+id as change_id,
+time_created,
 event_type 
 FROM four_keys.events_raw 
-WHERE event_type in ("pull_request", "push") 
-GROUP BY 1,2,3;
+WHERE event_type in ("pull_request", "push", "merge_request")
+GROUP BY 1,2,3,4;

--- a/queries/deployments.sql
+++ b/queries/deployments.sql
@@ -1,36 +1,42 @@
+# Deployments Table
 CREATE TEMP FUNCTION json2array(json STRING)
 RETURNS ARRAY<STRING>
 LANGUAGE js AS """
   return JSON.parse(json).map(x=>JSON.stringify(x));
 """; 
 
-SELECT 
-deploy_id, 
-time_created, 
-ARRAY_AGG(DISTINCT JSON_EXTRACT_SCALAR(changes, "$.id")) changes 
-FROM
-( 
-	SELECT 
-	deploy_id, 
-	deploys.time_created 
-	time_created, 
-	change_metadata, 
-	json2array(JSON_EXTRACT(change_metadata, "$.commits")) array_commits 
-	FROM (
-			SELECT 
-			id as deploy_id, 
-			time_created, 
-			IF(source = "cloud_build", 
-			   JSON_EXTRACT_SCALAR(metadata, "$.substitutions.COMMIT_SHA"),
-			   JSON_EXTRACT_SCALAR(metadata, "$.deployment.sha")) as main_commit 
-			FROM four_keys.events_raw 
-			WHERE (source = "cloud_build" AND JSON_EXTRACT_SCALAR(metadata, "$.status") = "SUCCESS") 
-			OR (source LIKE "github%" and event_type = "deployment") 
-			) deploys 
-		JOIN (
-			SELECT 
-			id, 
-			metadata as change_metadata 
-			FROM four_keys.events_raw) changes on deploys.main_commit = changes.id
-) d, d.array_commits changes 
-GROUP BY 1,2;
+SELECT
+source,
+deploy_id,
+time_created,
+ARRAY_AGG(DISTINCT JSON_EXTRACT_SCALAR(changes, '$.id')) changes
+FROM(
+  SELECT 
+  source,
+  deploy_id,
+  deploys.time_created time_created,
+  change_metadata,
+  json2array(JSON_EXTRACT(change_metadata, '$.commits')) array_commits
+  FROM
+    (
+    SELECT 
+    source,
+    id as deploy_id,
+    time_created,
+    CASE WHEN source = "cloud_build" then JSON_EXTRACT_SCALAR(metadata, '$.substitutions.COMMIT_SHA')
+         WHEN source like "github%" then JSON_EXTRACT_SCALAR(metadata, '$.deployment.sha')
+         WHEN source like "gitlab%" then JSON_EXTRACT_SCALAR(metadata, '$.commit.id') end as main_commit
+    FROM four_keys.events_raw 
+    WHERE ((source = "cloud_build"
+    AND JSON_EXTRACT_SCALAR(metadata, '$.status') = "SUCCESS")
+    OR (source LIKE "github%" and event_type = "deployment")
+    OR (source LIKE "gitlab%" and event_type = "pipeline" and JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.status') = "success"))
+    ) deploys
+  JOIN 
+    (SELECT
+    id,
+    metadata as change_metadata
+    FROM four_keys.events_raw) 
+    changes on deploys.main_commit = changes.id) d, d.array_commits changes
+GROUP BY 1,2,3
+;

--- a/queries/incidents.sql
+++ b/queries/incidents.sql
@@ -1,17 +1,27 @@
+# Incidents Table
+SELECT
+source,
+incident_id,
+TIMESTAMP(MIN(time_created)) time_created,
+TIMESTAMP(MAX(time_resolved)) as time_resolved,
+ARRAY_AGG(root_cause IGNORE NULLS) changes,
+FROM
+(
 SELECT 
-incident_id, 
-TIMESTAMP(time_created) time_created, 
-TIMESTAMP(MAX(time_resolved)) as time_resolved, 
-ARRAY_AGG(root_cause IGNORE NULLS) changes, 
-FROM (
- SELECT 
- JSON_EXTRACT_SCALAR(metadata, "$.issue.number") as incident_id, 
- JSON_EXTRACT_SCALAR(metadata, "$.issue.created_at") as time_created, 
- JSON_EXTRACT_SCALAR(metadata, "$.issue.closed_at") as time_resolved, 
- REGEXP_EXTRACT(metadata, r"root cause: ([[:alnum:]]*)") as root_cause, 
- REGEXP_CONTAINS(JSON_EXTRACT(metadata, "$.issue.labels"), '"name":"Incident"') as bug 
- FROM four_keys.events_raw 
- WHERE event_type LIKE "issue%"
- ) 
-GROUP BY 1,2 
-HAVING max(bug) is True;
+source,
+CASE WHEN source LIKE "github%" THEN JSON_EXTRACT_SCALAR(metadata, '$.issue.number')
+     WHEN source LIKE "gitlab%" AND event_type = "note" THEN JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.noteable_id')
+     WHEN source LIKE "gitlab%" AND event_type = "issue" THEN JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.id') end as incident_id,
+CASE WHEN source LIKE "github%" THEN JSON_EXTRACT_SCALAR(metadata, '$.issue.created_at')
+     WHEN source LIKE "gitlab%" THEN JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.created_at') end as time_created,
+CASE WHEN source LIKE "github%" THEN JSON_EXTRACT_SCALAR(metadata, '$.issue.closed_at')
+     WHEN source LIKE "gitlab%" THEN JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.closed_at') end as time_resolved,
+REGEXP_EXTRACT(metadata, r"root cause: ([[:alnum:]]*)") as root_cause,
+CASE WHEN source LIKE "github%" THEN REGEXP_CONTAINS(JSON_EXTRACT(metadata, '$.issue.labels'), '"name":"Incident"')
+     WHEN source LIKE "gitlab%" THEN REGEXP_CONTAINS(JSON_EXTRACT(metadata, '$.object_attributes.labels'), '"title":"Incident"') end as bug,
+FROM four_keys.events_raw 
+WHERE event_type LIKE "issue%" OR (event_type = "note" and JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.noteable_type') = 'Issue')
+)
+GROUP BY 1,2
+HAVING max(bug) is True
+;

--- a/queries/schedule.py
+++ b/queries/schedule.py
@@ -25,11 +25,12 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string('table', '', 'Table name for scheduled query output')
 flags.DEFINE_string('query_file', '', 'Query to schedule')
 
+PROJECT_ID = os.environ.get("FOURKEYS_PROJECT")
 
 def create_or_update_scheduled_query(argv):
     # Set up the client 
     client = bigquery_datatransfer_v1.DataTransferServiceClient()
-    parent = client.project_path(os.environ.get("FOURKEYS_PROJECT"))
+    parent = client.project_path(PROJECT_ID)
 
     # Flags from command line
     table = FLAGS.table

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -60,7 +60,6 @@ fourkeys_project_setup () {
   fi
 
   export FOURKEYS_REGION=us-central1
-  export SSH_PRIVATE_KEY=$(cat ~/.ssh/id_rsa)
 
   echo "Setting up project for Four Keys Dashboard..."; set -x
   export FOURKEYS_PROJECTNUM=$(gcloud projects list --filter="${FOURKEYS_PROJECT}" --format="value(PROJECT_NUMBER)")
@@ -87,65 +86,31 @@ fourkeys_project_setup () {
     --member serviceAccount:${FOURKEYS_PROJECTNUM}@cloudbuild.gserviceaccount.com \
     --role roles/iam.serviceAccountUser
 
-  echo "Creating Github event handler Pub/Sub topic..."; set -x
-  gcloud pubsub topics create GitHub-Hookshot
-  set +x; echo
-
-  echo "Creating Gitlab event handler Pub/Sub topic..."; set -x
-  gcloud pubsub topics create Gitlab
-  set +x; echo
-
-  echo "Creating cloud-builds topic..."; set -x
-  gcloud pubsub topics create cloud-builds
-  set +x; echo
-
-  echo "Deploying event handler..."; set -x
+  echo "Deploying event-handler..."; set -x
   cd $DIR/../event_handler
   gcloud builds submit --substitutions _TAG=latest,_REGION=${FOURKEYS_REGION} .
   set +x; echo
 
-  echo "Deploying BQ github worker..."; set -x
-  cd $DIR/../bq_workers/github_parser
-  gcloud builds submit --substitutions _TAG=latest,_REGION=${FOURKEYS_REGION} .
-  set +x; echo
-
-  echo "Deploying BQ cloud build worker..."; set -x
-  cd $DIR/../bq_workers/cloud_build_parser
-  gcloud builds submit --substitutions _TAG=latest,_REGION=${FOURKEYS_REGION} . 
-  set +x; echo
-
-  echo "Creating BQ worker Pub/Sub subscription..."; set -x
-  # grant Cloud Pub/Sub the permission to create tokens
+  echo "Grant Cloud Pub/Sub the permission to create tokens..."; set -x
   export PUBSUB_SERVICE_ACCOUNT="service-${FOURKEYS_PROJECTNUM}@gcp-sa-pubsub.iam.gserviceaccount.com"
   gcloud projects add-iam-policy-binding ${FOURKEYS_PROJECT} \
     --member="serviceAccount:${PUBSUB_SERVICE_ACCOUNT}"\
     --role='roles/iam.serviceAccountTokenCreator'
+
   gcloud iam service-accounts create cloud-run-pubsub-invoker \
      --display-name "Cloud Run Pub/Sub Invoker"
-  gcloud run  --platform managed services add-iam-policy-binding github-worker \
-   --member="serviceAccount:cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com" \
-   --role=roles/run.invoker
-  gcloud run  --platform managed services add-iam-policy-binding cloud-build-worker \
-   --member="serviceAccount:cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com" \
-   --role=roles/run.invoker
-
-  # Get push endpoint for github-worker
-  export PUSH_ENDPOINT_URL=$(gcloud run --platform managed --region ${FOURKEYS_REGION} services describe github-worker --format=yaml | grep url | head -1 | sed -e 's/  *url: //g')
-  # configure the subscription push identity
-  gcloud pubsub subscriptions create GithubSubscription \
-    --topic=GitHub-Hookshot \
-    --push-endpoint=${PUSH_ENDPOINT_URL} \
-    --push-auth-service-account=cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com
   set +x; echo
 
-  # Get push endpoint for cloud-build-worker
-  export PUSH_ENDPOINT_URL=$(gcloud run --platform managed --region ${FOURKEYS_REGION} services describe cloud-build-worker --format=yaml | grep url | head -1 | sed -e 's/  *url: //g')
-  # configure the subscription push identity
-  gcloud pubsub subscriptions create CloudBuildSubscription \
-    --topic=cloud-builds \
-    --push-endpoint=${PUSH_ENDPOINT_URL} \
-    --push-auth-service-account=cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com
-  set +x; echo
+  echo "Creating source pipelines"
+  if [[ ${gitlab_yesno} == "y" ]]
+  then gitlab_pipeline
+  fi
+  if [[ ${github_yesno} == "y" ]]
+  then github_pipeline
+  fi
+
+  # Always assume cloud-build pipeline
+  cloud_build_pipeline
 
   echo "Creating BigQuery dataset and tables"; set -x
   bq mk \
@@ -173,7 +138,7 @@ fourkeys_project_setup () {
     $DIR/incidents_schema.json
   set +x; echo
 
-  echo "Saving Github Secret in Secret Manager.."; set -x\
+  echo "Saving Event Handler Secret in Secret Manager.."; set -x\
   # Set permissions so Cloud Run can access secrets
   SERVICE_ACCOUNT=$(gcloud iam service-accounts list --format 'value(EMAIL)' \
     --filter 'NAME:Default compute service account')
@@ -224,20 +189,114 @@ helloworld_project_setup () {
 
 }
 
+github_pipeline(){
+  echo "Creating Github Data Pipeline..."
+
+  echo "Deploying BQ github worker..."; set -x
+  cd $DIR/../bq_workers/github_parser
+  gcloud builds submit --substitutions _TAG=latest,_REGION=${FOURKEYS_REGION} .
+  set +x; echo
+
+  echo "Creating Github Pub/Sub Topic & Subscription..."
+  gcloud pubsub topics create GitHub-Hookshot
+
+  echo "Creating cloud-builds topic..."; set -x
+  gcloud pubsub topics create cloud-builds
+  set +x; echo
+
+  gcloud run  --platform managed services add-iam-policy-binding github-worker \
+   --member="serviceAccount:cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com" \
+   --role=roles/run.invoker
+
+  # Get push endpoint for github-worker
+  export PUSH_ENDPOINT_URL=$(gcloud run --platform managed --region ${FOURKEYS_REGION} services describe github-worker --format=yaml | grep url | head -1 | sed -e 's/  *url: //g')
+  # configure the subscription push identity
+  gcloud pubsub subscriptions create GithubSubscription \
+    --topic=GitHub-Hookshot \
+    --push-endpoint=${PUSH_ENDPOINT_URL} \
+    --push-auth-service-account=cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com
+  set +x; echo
+  cd $DIR
+}
+
+gitlab_pipeline(){
+  echo "Creating Gitlab Data Pipeline..."
+
+  echo "Deploying BQ gitlab worker..."; set -x
+  cd $DIR/../bq_workers/gitlab_parser
+  gcloud builds submit --substitutions _TAG=latest,_REGION=${FOURKEYS_REGION} .
+  set +x; echo
+
+  echo "Creating Github Pub/Sub Topic & Subscription..."
+  gcloud pubsub topics create Gitlab
+
+  gcloud run  --platform managed services add-iam-policy-binding gitlab-worker \
+   --member="serviceAccount:cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com" \
+   --role=roles/run.invoker
+
+  # Get push endpoint for gitlab-worker
+  export PUSH_ENDPOINT_URL=$(gcloud run --platform managed --region ${FOURKEYS_REGION} services describe gitlab-worker --format=yaml | grep url | head -1 | sed -e 's/  *url: //g')
+  # configure the subscription push identity
+  gcloud pubsub subscriptions create GitlabSubscription \
+    --topic=Gitlab \
+    --push-endpoint=${PUSH_ENDPOINT_URL} \
+    --push-auth-service-account=cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com
+  set +x; echo
+  cd $DIR
+}
+
+
+cloud_build_pipeline(){
+  echo "Creating Cloud Build Data Pipeline..."
+
+  echo "Deploying BQ cloud build worker..."; set -x
+  cd $DIR/../bq_workers/cloud_build_parser
+  gcloud builds submit --substitutions _TAG=latest,_REGION=${FOURKEYS_REGION} . 
+  set +x; echo
+
+  echo "Creating cloud-builds topic..."; set -x
+  gcloud pubsub topics create cloud-builds
+  set +x; echo
+
+  gcloud run  --platform managed services add-iam-policy-binding cloud-build-worker \
+   --member="serviceAccount:cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com" \
+   --role=roles/run.invoker
+
+  # Get push endpoint for cloud-build-worker
+  export PUSH_ENDPOINT_URL=$(gcloud run --platform managed --region ${FOURKEYS_REGION} services describe cloud-build-worker --format=yaml | grep url | head -1 | sed -e 's/  *url: //g')
+  # configure the subscription push identity
+  gcloud pubsub subscriptions create CloudBuildSubscription \
+    --topic=cloud-builds \
+    --push-endpoint=${PUSH_ENDPOINT_URL} \
+    --push-auth-service-account=cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com
+  set +x; echo
+  cd $DIR
+}
+
 generate_data(){
   gcloud config set project ${FOURKEYS_PROJECT}
   echo "Creating mock data..."; 
   export WEBHOOK=$(gcloud run --platform managed --region ${FOURKEYS_REGION} services describe event-handler --format=yaml | grep url | head -1 | sed -e 's/  *url: //g')
-  export GITHUB_SECRET=$SECRET
+  export SECRET=$SECRET
 
+
+  if [[ ${gitlab_yesno} == "y" ]]
   set -x
-  python3 ${DIR}/../data_generator/data.py
+  then python3 ${DIR}/../data_generator/gitlab_data.py
   set +x
+  fi
+  if [[ ${github_yesno} == "y" ]]
+  set -x
+  then python3 ${DIR}/../data_generator/github_data.py  
+  set +x
+  fi
+  
 }
 
 schedule_bq_queries(){
   cd ${DIR}/../queries/
   pip3 install -r requirements.txt -q
+
   echo "Creating BigQuery scheduled queries for derived tables.."; set -x
 
   python3 schedule.py --query_file=changes.sql --table=changes
@@ -277,6 +336,9 @@ create_new_project
 else project_prompt
 fi
 
+# Create workers for the correct sources
+read -p "Are you using Gitlab? (y/n):" gitlab_yesno
+read -p "Are you using Github? (y/n):" github_yesno
 fourkeys_project_setup
 
 read -p "Would you like to create a separate new project to test deployments for the four key metrics? (y/n):" test_yesno

--- a/shared/shared.py
+++ b/shared/shared.py
@@ -18,7 +18,8 @@ from google.cloud import bigquery
 
 
 def insert_row_into_bigquery(event):
-    assert event, "No data to insert"
+    if not event:
+        raise Exception("No data to insert")
 
     # Set up bigquery instance
     client = bigquery.Client()


### PR DESCRIPTION
- Updating queries to include gitlab data
- Adding gitlab as an authorized source
- Adding the gitlab-worker for ETL
- Updating the setup script to only build the necessary cloud run workers (ie only build gitlab-worker if you're using gitlab, only build github-worker if you're using github)
- Renaming secret so it's event-handler secret, not "github"
- Adding "source" to the derived tables