### PR TITLE
Adding cloudbuild CI/CD for testing

### DIFF
--- a/tests.cloudbuild.yaml
+++ b/tests.cloudbuild.yaml
@@ -1,0 +1,7 @@
+steps:
+  - name: gcr.io/cloud-devrel-public-resources/python-multi
+    entrypoint: /bin/bash
+    args:
+       - '-c'
+       - |
+        pip3 install nox && python3 -m nox


### PR DESCRIPTION
Simple Nox execution for PR's -- runs affected unit tests and runs a Python linter. 