### PR TITLE
Use deployment_status event for GitHub

### DIFF
--- a/bq_workers/github_parser/main.py
+++ b/bq_workers/github_parser/main.py
@@ -82,7 +82,7 @@ def process_github_event(headers, msg):
     types = {"push", "pull_request", "pull_request_review",
              "pull_request_review_comment", "issues",
              "issue_comment", "check_run", "check_suite", "status",
-             "deployment", "release"}
+             "deployment_status", "release"}
 
     if event_type not in types:
         raise Exception("Unsupported GitHub event: '%s'" % event_type)
@@ -123,9 +123,9 @@ def process_github_event(headers, msg):
                         metadata["check_suite"]["created_at"])
         e_id = metadata["check_suite"]["id"]
 
-    if event_type == "deployment":
-        time_created = metadata["deployment"]["updated_at"]
-        e_id = metadata["deployment"]["id"]
+    if event_type == "deployment_status":
+        time_created = metadata["deployment_status"]["updated_at"]
+        e_id = metadata["deployment_status"]["id"]
 
     if event_type == "status":
         time_created = metadata["updated_at"]

--- a/queries/deployments.sql
+++ b/queries/deployments.sql
@@ -31,7 +31,7 @@ FROM(
       FROM four_keys.events_raw 
       WHERE ((source = "cloud_build"
       AND JSON_EXTRACT_SCALAR(metadata, '$.status') = "SUCCESS")
-      OR (source LIKE "github%" and event_type = "deployment")
+      OR (source LIKE "github%" and event_type = "deployment_status" and JSON_EXTRACT_SCALAR(metadata, '$.deployment_status.state') = "success")
       OR (source LIKE "gitlab%" and event_type = "pipeline" and JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.status') = "success"))
     ) 
     UNION ALL


### PR DESCRIPTION
GitHub parser & deployments.sql collect failed deployments as well as succeeded ones (more precisely, deployment event itself has no status information) and insert into deployments table. 

And then, both kind of deployments are taken into consideration when calculating deployment frequency and lead times.

This is unexpected behavior for me (or perhaps for us), so I suppose it's more appropriate using deployment_status events with `success` state.

Can I get your opinion?