### PR TITLE
Authenticated for E2E tests

### DIFF
--- a/data_generator/github_data.py
+++ b/data_generator/github_data.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import datetime
 import hmac
 import json
@@ -75,6 +74,10 @@ def send_mock_github_events(event_type, data):
     request.add_header("User-Agent", "GitHub-Hookshot/mock")
     request.add_header("Content-Type", "application/json")
     request.add_header("Mock", True)
+
+    token = os.environ.get("TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
 
     response = urlopen(request)
 

--- a/data_generator/github_data.py
+++ b/data_generator/github_data.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import datetime
 import hmac
 import json

--- a/data_generator/gitlab_data.py
+++ b/data_generator/gitlab_data.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from absl import app
-from absl import flags
 
 import datetime
 import json

--- a/data_generator/gitlab_data.py
+++ b/data_generator/gitlab_data.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from absl import app
+from absl import flags
 
 import datetime
 import json
@@ -77,6 +79,10 @@ def send_mock_gitlab_events(event_type, data):
     request.add_header("X-Gitlab-Token", secret)
     request.add_header("Content-Type", "application/json")
     request.add_header("Mock", True)
+
+    token = os.environ.get("TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
 
     response = urlopen(request)
 

--- a/e2e_tests.cloudbuild.yaml
+++ b/e2e_tests.cloudbuild.yaml
@@ -9,11 +9,12 @@ steps:
         cd setup/
         export FOURKEYS_PROJECT=${PROJECT_ID}
 
-        # Create identity-token
+        # Create identity-token        
         export TOKEN=$(curl -X POST -H "content-type: application/json" \
         -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-        -d '{"audience": "${WEBHOOK}"}' \
-         "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${FOURKEYS_PROJECTNUM}@cloudbuild.gserviceaccount.com:generateIdToken")
+        -d "{\"audience\": \"run.googleapis.com\" }" \
+         "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/cloud-run-pubsub-invoker@${PROJECT_ID}.iam.gserviceaccount.com:generateIdToken" | \
+         python3 -c "import sys, json; print(json.load(sys.stdin)['token'])")
 
         # passing in responses to the prompts
         # "n\ny\n2\n1\nn\ny\n" maps to:

--- a/e2e_tests.cloudbuild.yaml
+++ b/e2e_tests.cloudbuild.yaml
@@ -9,6 +9,12 @@ steps:
         cd setup/
         export FOURKEYS_PROJECT=${PROJECT_ID}
 
+        # Create identity-token
+        export TOKEN=$(curl -X POST -H "content-type: application/json" \
+        -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+        -d '{"audience": "${WEBHOOK}"}' \
+         "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${FOURKEYS_PROJECTNUM}@cloudbuild.gserviceaccount.com:generateIdToken")
+
         # passing in responses to the prompts
         # "n\ny\n2\n1\nn\ny\n" maps to:
         ### No, do not make new project

--- a/e2e_tests.cloudbuild.yaml
+++ b/e2e_tests.cloudbuild.yaml
@@ -16,6 +16,8 @@ steps:
          "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/cloud-run-pubsub-invoker@${PROJECT_ID}.iam.gserviceaccount.com:generateIdToken" | \
          python3 -c "import sys, json; print(json.load(sys.stdin)['token'])")
 
+        echo $TOKEN
+
         # passing in responses to the prompts
         # "n\ny\n2\n1\nn\ny\n" maps to:
         ### No, do not make new project

--- a/e2e_tests.cloudbuild.yaml
+++ b/e2e_tests.cloudbuild.yaml
@@ -9,15 +9,6 @@ steps:
         cd setup/
         export FOURKEYS_PROJECT=${PROJECT_ID}
 
-        # Create identity-token        
-        export TOKEN=$(curl -X POST -H "content-type: application/json" \
-        -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-        -d "{\"audience\": \"run.googleapis.com\" }" \
-         "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/cloud-run-pubsub-invoker@${PROJECT_ID}.iam.gserviceaccount.com:generateIdToken" | \
-         python3 -c "import sys, json; print(json.load(sys.stdin)['token'])")
-
-        echo $TOKEN
-
         # passing in responses to the prompts
         # "n\ny\n2\n1\nn\ny\n" maps to:
         ### No, do not make new project

--- a/event_handler/event_handler.py
+++ b/event_handler/event_handler.py
@@ -51,7 +51,8 @@ def index():
 
     # Remove the Auth header so we do not publish it to Pub/Sub
     pubsub_headers = dict(request.headers)
-    del pubsub_headers["Authorization"]
+    if "Authorization" in pubsub_headers: 
+        del pubsub_headers["Authorization"]
 
     # Publish to Pub/Sub
     publish_to_pubsub(source, body, pubsub_headers)

--- a/event_handler/event_handler.py
+++ b/event_handler/event_handler.py
@@ -49,8 +49,12 @@ def index():
     if not verify_signature(signature, body):
         raise Exception("Unverified Signature")
 
+    # Remove the Auth header so we do not publish it to Pub/Sub
+    pubsub_headers = dict(request.headers)
+    del pubsub_headers["Authorization"]
+
     # Publish to Pub/Sub
-    publish_to_pubsub(source, body, dict(request.headers))
+    publish_to_pubsub(source, body, pubsub_headers)
 
     # Flush the stdout to avoid log buffering.
     sys.stdout.flush()

--- a/event_handler/event_handler.py
+++ b/event_handler/event_handler.py
@@ -51,7 +51,7 @@ def index():
 
     # Remove the Auth header so we do not publish it to Pub/Sub
     pubsub_headers = dict(request.headers)
-    if "Authorization" in pubsub_headers: 
+    if "Authorization" in pubsub_headers:
         del pubsub_headers["Authorization"]
 
     # Publish to Pub/Sub

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -324,6 +324,7 @@ generate_data(){
   echo "Creating mock data..."; 
   export WEBHOOK=$(gcloud run --platform managed --region ${FOURKEYS_REGION} services describe event-handler --format=yaml | grep url | head -1 | sed -e 's/  *url: //g')
   export SECRET=$SECRET
+  echo $TOKEN
 
   if [[ ${git_system} == "1" ]]
   then set -x; python3 ${DIR}/../data_generator/gitlab_data.py

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -329,7 +329,7 @@ generate_data(){
   export TOKEN=$(curl -X POST -H "content-type: application/json" \
         -H "Authorization: Bearer $(gcloud auth print-access-token)" \
         -d '{"audience": "${WEBHOOK}"}' \
-         "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com:generateIdToken")
+         "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${FOURKEYS_PROJECTNUM}@cloudbuild.gserviceaccount.com:generateIdToken")
 
   if [[ ${git_system} == "1" ]]
   then set -x; python3 ${DIR}/../data_generator/gitlab_data.py

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -326,7 +326,7 @@ generate_data(){
   export SECRET=$SECRET
 
   # If event-handler requires authorization, pass it token
-  export token=$(gcloud auth print-access-token)
+  export token=$(gcloud auth print-identity-token)
 
   if [[ ${git_system} == "1" ]]
   then set -x; python3 ${DIR}/../data_generator/gitlab_data.py

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -325,6 +325,9 @@ generate_data(){
   export WEBHOOK=$(gcloud run --platform managed --region ${FOURKEYS_REGION} services describe event-handler --format=yaml | grep url | head -1 | sed -e 's/  *url: //g')
   export SECRET=$SECRET
 
+  # If event-handler requires authorization, pass it token
+  export token=$(gcloud auth print-access-token)
+
   if [[ ${git_system} == "1" ]]
   then set -x; python3 ${DIR}/../data_generator/gitlab_data.py
   set +x

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -325,12 +325,6 @@ generate_data(){
   export WEBHOOK=$(gcloud run --platform managed --region ${FOURKEYS_REGION} services describe event-handler --format=yaml | grep url | head -1 | sed -e 's/  *url: //g')
   export SECRET=$SECRET
 
-  # If event-handler requires authorization, pass it token
-  export TOKEN=$(curl -X POST -H "content-type: application/json" \
-        -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-        -d '{"audience": "${WEBHOOK}"}' \
-         "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${FOURKEYS_PROJECTNUM}@cloudbuild.gserviceaccount.com:generateIdToken")
-
   if [[ ${git_system} == "1" ]]
   then set -x; python3 ${DIR}/../data_generator/gitlab_data.py
   set +x

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -326,7 +326,10 @@ generate_data(){
   export SECRET=$SECRET
 
   # If event-handler requires authorization, pass it token
-  export token=$(gcloud auth print-identity-token)
+  export TOKEN=$(curl -X POST -H "content-type: application/json" \
+        -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+        -d '{"audience": "${WEBHOOK}"}' \
+         "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/cloud-run-pubsub-invoker@${FOURKEYS_PROJECT}.iam.gserviceaccount.com:generateIdToken")
 
   if [[ ${git_system} == "1" ]]
   then set -x; python3 ${DIR}/../data_generator/gitlab_data.py

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -324,6 +324,14 @@ generate_data(){
   echo "Creating mock data..."; 
   export WEBHOOK=$(gcloud run --platform managed --region ${FOURKEYS_REGION} services describe event-handler --format=yaml | grep url | head -1 | sed -e 's/  *url: //g')
   export SECRET=$SECRET
+
+  # Create identity-token        
+  export TOKEN=$(curl -X POST -H "content-type: application/json" \
+    -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+    -d "{\"audience\": \"${WEBHOOK}\" }" \
+     "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/cloud-run-pubsub-invoker@${PROJECT_ID}.iam.gserviceaccount.com:generateIdToken" | \
+     python3 -c "import sys, json; print(json.load(sys.stdin)['token'])")
+
   echo $TOKEN
 
   if [[ ${git_system} == "1" ]]


### PR DESCRIPTION
We want to use authenticated services in the E2E testing.  

- Setup script generates an id_token if it's being executed by the Cloud Build service account.
- Data Generator attaches the auth token to the request
- Event Handler does not publish the Auth token to pub/sub