### PR TITLE
Fixing anchor links in INSTALL.md

### DIFF
--- a/setup/INSTALL.md
+++ b/setup/INSTALL.md
@@ -2,11 +2,11 @@
 
 This guide describes how to set up Four Keys with your GitHub or GitLab project. The main setps are:
 
-1.  [Runing the setup script](#running_the_setup_script)
+1.  [Runing the setup script](#running-the-setup-script)
 1.  Integrating with your GitHub or Git Lab repo by:
-    1.  [Collecting changes data](#collecting_changes_data)
-    1.  [Collecting deployment data](#collecting_deployment_data)
-    1.  [Collecting incident data](#collecting_incident_data)
+    1.  [Collecting changes data](#collecting-changes-data)
+    1.  [Collecting deployment data](#collecting-deployment-data)
+    1.  [Collecting incident data](#collecting-incident-data)
 
 ## Before you begin
 
@@ -80,9 +80,9 @@ The setup script can create mock data, but it cannot integrate automatically wit
 
 To integrate Four Keys with a live repo, you need to:
 
-1.  [Collect changes data](#collecting_changes_data)
-1.  [Collect deployment data](#collecting_deployment_data)
-1.  [Collect incident data](#collecting_incident_data)
+1.  [Collect changes data](#collecting-changes-data)
+1.  [Collect deployment data](#collecting-deployment-data)
+1.  [Collect incident data](#collecting-incident-data)
 
 ### Collecting changes data
 


### PR DESCRIPTION
Some of the anchor links are not working. Need to use `-` instead of `_`.

- current: https://github.com/GoogleCloudPlatform/fourkeys/blob/d6f11f774f18753d9daadec3200c448e8050b0c4/setup/INSTALL.md

- fixed: [fourkeys/INSTALL.md at fix-md-anchor · pokutuna/fourkeys](https://github.com/pokutuna/fourkeys/blob/fix-md-anchor/setup/INSTALL.md)