### PR TITLE
Support multiple commits per deployment

### DIFF
--- a/queries/deployments.sql
+++ b/queries/deployments.sql
@@ -28,11 +28,10 @@ FROM(
       CASE WHEN source = "cloud_build" then JSON_EXTRACT_SCALAR(metadata, '$.substitutions.COMMIT_SHA')
            WHEN source like "github%" then JSON_EXTRACT_SCALAR(metadata, '$.deployment.sha')
            WHEN source like "gitlab%" then JSON_EXTRACT_SCALAR(metadata, '$.commit.id') end as main_commit,
-      CASE WHEN source = "cloud_build" THEN []
-           WHEN source LIKE "github%" THEN ARRAY(
+      CASE WHEN source LIKE "github%" THEN ARRAY(
                 SELECT JSON_EXTRACT_SCALAR(string_element, '$')
                 FROM UNNEST(JSON_EXTRACT_ARRAY(metadata, '$.deployment.additional_sha')) AS string_element)
-           WHEN source LIKE "gitlab%" THEN [] end as additional_commits
+           ELSE [] end as additional_commits
       FROM four_keys.events_raw 
       WHERE ((source = "cloud_build"
       AND JSON_EXTRACT_SCALAR(metadata, '$.status') = "SUCCESS")

--- a/queries/deployments.sql
+++ b/queries/deployments.sql
@@ -27,7 +27,12 @@ FROM(
       time_created,
       CASE WHEN source = "cloud_build" then JSON_EXTRACT_SCALAR(metadata, '$.substitutions.COMMIT_SHA')
            WHEN source like "github%" then JSON_EXTRACT_SCALAR(metadata, '$.deployment.sha')
-           WHEN source like "gitlab%" then JSON_EXTRACT_SCALAR(metadata, '$.commit.id') end as main_commit
+           WHEN source like "gitlab%" then JSON_EXTRACT_SCALAR(metadata, '$.commit.id') end as main_commit,
+      CASE WHEN source = "cloud_build" THEN []
+           WHEN source LIKE "github%" THEN ARRAY(
+                SELECT JSON_EXTRACT_SCALAR(string_element, '$')
+                FROM UNNEST(JSON_EXTRACT_ARRAY(metadata, '$.deployment.additional_sha')) AS string_element)
+           WHEN source LIKE "gitlab%" THEN [] end as additional_commits
       FROM four_keys.events_raw 
       WHERE ((source = "cloud_build"
       AND JSON_EXTRACT_SCALAR(metadata, '$.status') = "SUCCESS")
@@ -40,7 +45,8 @@ FROM(
       source,
       id as deploy_id,
       time_created,
-      IF(JSON_EXTRACT_SCALAR(param, '$.name') = "gitrevision", JSON_EXTRACT_SCALAR(param, '$.value'), Null) as main_commit
+      IF(JSON_EXTRACT_SCALAR(param, '$.name') = "gitrevision", JSON_EXTRACT_SCALAR(param, '$.value'), Null) as main_commit,
+      [] AS additional_commits
       FROM (
       SELECT 
       id,
@@ -57,6 +63,9 @@ FROM(
     id,
     metadata as change_metadata
     FROM four_keys.events_raw) 
-    changes on deploys.main_commit = changes.id) d, d.array_commits changes
+    changes on (
+        changes.id = deploys.main_commit
+        or changes.id in unnest(deploys.additional_commits)
+      )) d, d.array_commits changes
 GROUP BY 1,2,3
 ;


### PR DESCRIPTION
This is one possible way to solve https://github.com/GoogleCloudPlatform/fourkeys/issues/46. Implementation is just for GitHub so far (since I don't have the others set up).
Deployment events can be created in same way as in https://github.com/GoogleCloudPlatform/fourkeys/blob/master/data_generator/github_data.py , but with the modification:

```python
def create_deploy_event(change):
    deployment = {
        "deployment_status": {
            "updated_at": change["timestamp"],
            "id": secrets.token_hex(20),
            "state": "success",
        },
        "deployment": {
           "sha": change["id"][0],
           "additional_sha": change["id"][1:],
        }
    }
    return deployment
```
The  `change["id"]` should be set to list of shas that should be included.

Getting the list of merges to master since previous commit can be done with something like:
`git log $LAST_PROD_DEPLOY..$CURRENT_GIT_SHA --decorate=no --date-order --reverse --format="%H"`

If the implementation seems to be on the right track an update to the documentation is needed as well.