### PR TITLE
Use the same random id for both projects

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -18,10 +18,11 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 environment () {
   # Set values that will be overwritten if env.sh exists
+  RANDOM_IDENTIFIER=$((RANDOM%999999))
   export PARENT_PROJECT=$(gcloud config get-value project)
-  export FOURKEYS_PROJECT=$(printf "fourkeys-%06d" $((RANDOM%999999)))
+  export FOURKEYS_PROJECT=$(printf "fourkeys-%06d" $RANDOM_IDENTIFIER)
   export FOURKEYS_REGION=us-central1
-  export HELLOWORLD_PROJECT=$(printf "helloworld-%06d" $((RANDOM%999999)))
+  export HELLOWORLD_PROJECT=$(printf "helloworld-%06d" $RANDOM_IDENTIFIER)
   export HELLOWORLD_REGION=us-central
   export HELLOWORLD_ZONE=${HELLOWORLD_REGION}1-a
   export PARENT_FOLDER=$(gcloud projects describe ${PARENT_PROJECT} --format="value(parent.id)")


### PR DESCRIPTION
`setup.sh` (optionally) creates two GCP projects with random identifiers. Let's use the _same_ identifier for both projects, to make it more obvious that they're related.