### PR TITLE
Use secretmanager v1 API instead of v1beta1

### DIFF
--- a/event_handler/sources.py
+++ b/event_handler/sources.py
@@ -16,7 +16,7 @@ import hmac
 from hashlib import sha1
 import os
 
-from google.cloud import secretmanager_v1beta1
+from google.cloud import secretmanager
 
 PROJECT_NAME = os.environ.get("PROJECT_NAME")
 

--- a/event_handler/sources.py
+++ b/event_handler/sources.py
@@ -69,7 +69,7 @@ def get_secret(project_name, secret_name, version_num):
     Returns secret payload from Cloud Secret Manager
     """
     try:
-        client = secretmanager_v1beta1.SecretManagerServiceClient()
+        client = secretmanager.SecretManagerServiceClient()
         name = client.secret_version_path(
             project_name, secret_name, version_num
         )


### PR DESCRIPTION
Hello!

I am engineer on the Secret Manager product and would like to update the version of the API you are using. V1 contains all of the same features as V1Beta1 is better supported. Let me know if you have any questions. 

Regards, 
Rachana