### PR TITLE
Importing or initializing environment for helloworld setup

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -449,7 +449,9 @@ fourkeys_project_setup
 
 read -p "Would you like to create a separate new project to test deployments for the four key metrics? (y/n):" test_yesno
 if [[ ${test_yesno} == "y" ]]
-then helloworld_project_setup
+then 
+environment
+helloworld_project_setup
 fi
 
 read -p "Would you like to generate mock data? (y/n):" mock_yesno

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -449,8 +449,7 @@ fourkeys_project_setup
 
 read -p "Would you like to create a separate new project to test deployments for the four key metrics? (y/n):" test_yesno
 if [[ ${test_yesno} == "y" ]]
-then 
-environment
+then environment
 helloworld_project_setup
 fi
 


### PR DESCRIPTION
Fixes #95

If the user provides own project ID for fourkeys project, the environment needs to be initialized before the helloworld setup.  
It does no harm to always call it before the helloworld setup, because if it's already been initialized, it will read in from the file.  