### PR TITLE
fix: use `latest` event-handler secret

### DIFF
--- a/event_handler/sources.py
+++ b/event_handler/sources.py
@@ -42,7 +42,7 @@ def github_verification(signature, body):
     expected_signature = "sha1="
     try:
         # Get secret from Cloud Secret Manager
-        secret = get_secret(PROJECT_NAME, "event-handler", "1")
+        secret = get_secret(PROJECT_NAME, "event-handler", "latest")
         # Compute the hashed signature
         hashed = hmac.new(secret, body, sha1)
         expected_signature += hashed.hexdigest()

--- a/experimental/terraform/.terraform.lock.hcl
+++ b/experimental/terraform/.terraform.lock.hcl
@@ -52,3 +52,21 @@ provider "registry.terraform.io/hashicorp/null" {
     "zh:dbdef21df0c012b0d08776f3d4f34eb0f2f229adfde07ff252a119e52c0f65b7",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/experimental/terraform/README.md
+++ b/experimental/terraform/README.md
@@ -4,14 +4,30 @@ This folder contains terraform scripts to provision all of the infrastructure in
 
 **DO NOT USE!** It's very early and very incomplete. (Though: holler if you want to contribute!)
 
+## How to use
+1. run `setup.sh`; this will:
+  * create a project for four keys
+  * purge all terraform state [useful during tf development]
+  * build the event-handler container using Cloud Build
+    * _(this is done outside of Terraform b/c local-exec is a mess)_
+  * create a `terraform.tfvars` file
+  * invoke terraform
+1. run the following commands to retrieve values needed for your SCM:
+  * ```
+    echo `terraform output -raw event-handler-endpoint`
+    echo `terraform output -raw event-handler-secret`
+    ```
+
+
 Current functionality (2021-02-19):
 - Create a GCP project (outside of terraform)
 - Build the event-handler container image and push to GCR [TODO: use AR instead]
 - Deploy the event-handler container as a Cloud Run service
-- Omit the event-handler endpoint as an output
+- Emit the event-handler endpoint as an output
+- Create and store webhook secret
+- Emit the secrfet as an output
 
 TODO:
-- Create and store webhook secret
 - Create pubsub
 - Set up BigQuery
 - Build and deploy bigquery workers

--- a/experimental/terraform/main.tf
+++ b/experimental/terraform/main.tf
@@ -10,7 +10,17 @@ resource "google_project_service" "bq_api" {
   service = "bigquery.googleapis.com"
 }
 
-module "cloud_run_service" {
+resource "google_project_service" "sm_api" {
+  service = "secretmanager.googleapis.com"
+}
+
+# needed in order to fetch the default GCE service account
+# TODO: is there a cleaner way to get this?
+resource "google_project_service" "gce_api" {
+  service = "compute.googleapis.com"
+}
+
+module "event_handler_service" {
   source            = "./cloud_run_service"
   google_project_id = var.google_project_id
   google_region     = var.google_region
@@ -30,8 +40,35 @@ resource "google_bigquery_dataset" "four_keys" {
 # When scheduled queries are implemented, try removing this.
 # (see https://github.com/GoogleCloudPlatform/fourkeys/pull/90#discussion_r604320593)
 resource "google_bigquery_table" "bq_table" {
-  for_each = toset(["events_raw","changes","deployments","incidents"])
+  for_each   = toset(["events_raw", "changes", "deployments", "incidents"])
   dataset_id = google_bigquery_dataset.four_keys.dataset_id
-  table_id = each.key
-  schema = file("../../setup/${each.key}_schema.json")
+  table_id   = each.key
+  schema     = file("../../setup/${each.key}_schema.json")
+}
+
+resource "random_id" "event-handler-random-value" {
+  byte_length = "20"
+}
+
+resource "google_secret_manager_secret" "event-handler-secret" {
+  secret_id = "event-handler"
+  replication {
+    automatic = true
+  }
+  depends_on = [google_project_service.sm_api]
+}
+
+resource "google_secret_manager_secret_version" "event-handler-secret-version" {
+  secret = google_secret_manager_secret.event-handler-secret.id
+  secret_data = random_id.event-handler-random-value.hex
+}
+
+data "google_compute_default_service_account" "default" {
+  depends_on = [google_project_service.gce_api]
+}
+
+resource "google_secret_manager_secret_iam_member" "event-handler" {
+  secret_id = google_secret_manager_secret.event-handler-secret.id
+  role = "roles/secretmanager.secretAccessor"
+  member = "serviceAccount:${data.google_compute_default_service_account.default.email}"
 }

--- a/experimental/terraform/outputs.tf
+++ b/experimental/terraform/outputs.tf
@@ -1,3 +1,12 @@
-output "cloud_run_endpoints" {
-  value = [for x in module.cloud_run_service[*]["cloud_run_endpoint"] : x]
+output "event-handler-endpoint" {
+  value = module.event_handler_service.cloud_run_endpoint
+}
+
+output "event-handler-secret" {
+  value = google_secret_manager_secret_version.event-handler-secret-version.secret_data
+  sensitive = true
+}
+
+output "run-service-account" {
+  value = data.google_compute_default_service_account.default.email
 }


### PR DESCRIPTION
To validate event-handler secret from SCM, use the "latest" version available in Secret Manager (fixes #101)

101