### PR TITLE
Update data.gs

### DIFF
--- a/connector/data.gs
+++ b/connector/data.gs
@@ -59,7 +59,8 @@ SELECT
     WHEN max(med_time_to_resolve_bucket) OVER () < 168 THEN "One week"
     WHEN max(med_time_to_resolve_bucket) OVER () < 672 THEN "One month"
     WHEN max(med_time_to_resolve_bucket) OVER () < 730 * 6 THEN "Six months"
-    ELSE "One year"
+    WHEN max(med_time_to_resolve_bucket) OVER () > 730 * 6 THEN "One year"
+    ELSE "null"
     END AS time_to_restore_buckets
 FROM
   (


### PR DESCRIPTION
Datastudio report shows time to restore as One year if there are no incidents in the previous 3 months. This will display null instead.