### PR TITLE
Tf resources round 3

### DIFF
--- a/experimental/terraform/README.md
+++ b/experimental/terraform/README.md
@@ -25,12 +25,12 @@ Current functionality (GitHub + Cloud Build only):
 - Deploy the event-handler container as a Cloud Run service
 - Emit the event-handler endpoint as an output
 - Create and store webhook secret
-- Emit the secret as an output
-
-TODO:
 - Create pubsub
 - Set up BigQuery
 - Build and deploy bigquery workers
+- Emit the secret as an output
+
+TODO:
 - Establish BigQuery data transfer
 - Populate Data Studio dashboard
 - (much else)

--- a/experimental/terraform/README.md
+++ b/experimental/terraform/README.md
@@ -19,13 +19,13 @@ This folder contains terraform scripts to provision all of the infrastructure in
     ```
 
 
-Current functionality (2021-02-19):
+Current functionality (GitHub + Cloud Build only):
 - Create a GCP project (outside of terraform)
 - Build the event-handler container image and push to GCR [TODO: use AR instead]
 - Deploy the event-handler container as a Cloud Run service
 - Emit the event-handler endpoint as an output
 - Create and store webhook secret
-- Emit the secrfet as an output
+- Emit the secret as an output
 
 TODO:
 - Create pubsub

--- a/experimental/terraform/main.tf
+++ b/experimental/terraform/main.tf
@@ -98,8 +98,8 @@ resource "google_pubsub_topic_iam_member" "event_handler_pubsub_write_iam" {
 }
 
 resource "google_bigquery_dataset_iam_member" "github_bq_write_iam" {
-	dataset_id = google_bigquery_dataset.four_keys.id
-	role = "roles/bigquery.dataEditor"
+	dataset_id = "four_keys"
+	role = "roles/bigquery.user"
 	member = "serviceAccount:${google_service_account.github_parser_service_account.email}"
 }
 

--- a/experimental/terraform/main.tf
+++ b/experimental/terraform/main.tf
@@ -97,19 +97,24 @@ resource "google_pubsub_topic_iam_member" "event_handler_pubsub_write_iam" {
 	member = "serviceAccount:${google_service_account.event_handler_service_account.email}"
 }
 
-resource "google_project_iam_member" "github_parser_bq_user" {
-	role = "roles/bigquery.admin"
+resource "google_project_iam_member" "github_parser_bq_project_access" {
+	role = "roles/bigquery.user"
 	member = "serviceAccount:${google_service_account.github_parser_service_account.email}"
 }
 
-resource "google_service_account" "cloud_run_pubsub_invoker_service_account" {
-  account_id   = "cloud-run-pubsub-invoker"
+resource "google_bigquery_dataset_iam_member" "github_parser_bq_dataset_access" {
+  dataset_id = "four_keys"
+  role       = "roles/bigquery.dataEditor"
+  member = "serviceAccount:${google_service_account.github_parser_service_account.email}"
+}
+
+resource "google_service_account" "pubsub_cloudrun_invoker" {
+  account_id   = "pubsub-cloudrun-invoker"
   display_name = "Service Account for PubSub --> Cloud Run"
 }
 
-# Is this confusingly named? This service account doesn't invoke pubsub, it invokes Cloud Run
-resource "google_project_iam_member" "cloud_run_pubsub_invoker_iam" {
-	member = "serviceAccount:${google_service_account.cloud_run_pubsub_invoker_service_account.email}"
+resource "google_project_iam_member" "pubsub_cloudrun_invoker_iam" {
+	member = "serviceAccount:${google_service_account.pubsub_cloudrun_invoker.email}"
 	role="roles/run.invoker"
 }
 
@@ -121,7 +126,7 @@ resource "google_pubsub_subscription" "github_subscription" {
 	  push_endpoint=module.github_parser_service.cloud_run_endpoint
 
 		oidc_token {
-			service_account_email=google_service_account.cloud_run_pubsub_invoker_service_account.email
+			service_account_email=google_service_account.pubsub_cloudrun_invoker.email
 		}
 
 	}

--- a/experimental/terraform/main.tf
+++ b/experimental/terraform/main.tf
@@ -97,9 +97,8 @@ resource "google_pubsub_topic_iam_member" "event_handler_pubsub_write_iam" {
 	member = "serviceAccount:${google_service_account.event_handler_service_account.email}"
 }
 
-resource "google_bigquery_dataset_iam_member" "github_bq_write_iam" {
-	dataset_id = "four_keys"
-	role = "roles/bigquery.user"
+resource "google_project_iam_member" "github_parser_bq_user" {
+	role = "roles/bigquery.admin"
 	member = "serviceAccount:${google_service_account.github_parser_service_account.email}"
 }
 

--- a/experimental/terraform/main.tf
+++ b/experimental/terraform/main.tf
@@ -63,8 +63,68 @@ resource "google_service_account" "event_handler_service_account" {
   display_name = "Service Account for Event Handler Cloud Run Service"
 }
 
+resource "google_service_account" "github_parser_service_account" {
+  account_id   = "github-parser"
+  display_name = "Service Account for GitHub Parser Cloud Run Service"
+}
+
 resource "google_secret_manager_secret_iam_member" "event-handler" {
   secret_id = google_secret_manager_secret.event-handler-secret.id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.event_handler_service_account.email}"
+}
+
+module "github_parser_service" {
+  source            = "./cloud_run_service"
+  google_project_id = var.google_project_id
+  google_region     = var.google_region
+  service_name      = "github-parser"
+  service_account   = google_service_account.github_parser_service_account.email
+
+  depends_on = [
+    google_project_service.run_api,
+  ]
+
+}
+
+resource "google_pubsub_topic" "github" {
+	name="GitHub-Hookshot"
+}
+
+resource "google_pubsub_topic_iam_member" "event_handler_pubsub_write_iam" {
+	topic = google_pubsub_topic.github.id
+	role = "roles/editor"
+	member = "serviceAccount:${google_service_account.event_handler_service_account.email}"
+}
+
+resource "google_bigquery_dataset_iam_member" "github_bq_write_iam" {
+	dataset_id = google_bigquery_dataset.four_keys.id
+	role = "roles/bigquery.dataEditor"
+	member = "serviceAccount:${google_service_account.github_parser_service_account.email}"
+}
+
+resource "google_service_account" "cloud_run_pubsub_invoker_service_account" {
+  account_id   = "cloud-run-pubsub-invoker"
+  display_name = "Service Account for PubSub --> Cloud Run"
+}
+
+# Is this confusingly named? This service account doesn't invoke pubsub, it invokes Cloud Run
+resource "google_project_iam_member" "cloud_run_pubsub_invoker_iam" {
+	member = "serviceAccount:${google_service_account.cloud_run_pubsub_invoker_service_account.email}"
+	role="roles/run.invoker"
+}
+
+resource "google_pubsub_subscription" "github_subscription" {
+	name="github-subscription"
+	topic=google_pubsub_topic.github.id
+
+	push_config {
+	  push_endpoint=module.github_parser_service.cloud_run_endpoint
+
+		oidc_token {
+			service_account_email=google_service_account.cloud_run_pubsub_invoker_service_account.email
+		}
+
+	}
+
 }

--- a/experimental/terraform/main.tf
+++ b/experimental/terraform/main.tf
@@ -88,24 +88,24 @@ module "github_parser_service" {
 }
 
 resource "google_pubsub_topic" "github" {
-	name="GitHub-Hookshot"
+  name = "GitHub-Hookshot"
 }
 
 resource "google_pubsub_topic_iam_member" "event_handler_pubsub_write_iam" {
-	topic = google_pubsub_topic.github.id
-	role = "roles/editor"
-	member = "serviceAccount:${google_service_account.event_handler_service_account.email}"
+  topic  = google_pubsub_topic.github.id
+  role   = "roles/editor"
+  member = "serviceAccount:${google_service_account.event_handler_service_account.email}"
 }
 
 resource "google_project_iam_member" "github_parser_bq_project_access" {
-	role = "roles/bigquery.user"
-	member = "serviceAccount:${google_service_account.github_parser_service_account.email}"
+  role   = "roles/bigquery.user"
+  member = "serviceAccount:${google_service_account.github_parser_service_account.email}"
 }
 
 resource "google_bigquery_dataset_iam_member" "github_parser_bq_dataset_access" {
   dataset_id = "four_keys"
   role       = "roles/bigquery.dataEditor"
-  member = "serviceAccount:${google_service_account.github_parser_service_account.email}"
+  member     = "serviceAccount:${google_service_account.github_parser_service_account.email}"
 }
 
 resource "google_service_account" "pubsub_cloudrun_invoker" {
@@ -114,21 +114,21 @@ resource "google_service_account" "pubsub_cloudrun_invoker" {
 }
 
 resource "google_project_iam_member" "pubsub_cloudrun_invoker_iam" {
-	member = "serviceAccount:${google_service_account.pubsub_cloudrun_invoker.email}"
-	role="roles/run.invoker"
+  member = "serviceAccount:${google_service_account.pubsub_cloudrun_invoker.email}"
+  role   = "roles/run.invoker"
 }
 
 resource "google_pubsub_subscription" "github_subscription" {
-	name="github-subscription"
-	topic=google_pubsub_topic.github.id
+  name  = "github-subscription"
+  topic = google_pubsub_topic.github.id
 
-	push_config {
-	  push_endpoint=module.github_parser_service.cloud_run_endpoint
+  push_config {
+    push_endpoint = module.github_parser_service.cloud_run_endpoint
 
-		oidc_token {
-			service_account_email=google_service_account.pubsub_cloudrun_invoker.email
-		}
+    oidc_token {
+      service_account_email = google_service_account.pubsub_cloudrun_invoker.email
+    }
 
-	}
+  }
 
 }

--- a/experimental/terraform/outputs.tf
+++ b/experimental/terraform/outputs.tf
@@ -2,6 +2,10 @@ output "event-handler-endpoint" {
   value = module.event_handler_service.cloud_run_endpoint
 }
 
+output "github-parser-endpoint" {
+  value = module.github_parser_service.cloud_run_endpoint
+}
+
 output "event-handler-secret" {
   value     = google_secret_manager_secret_version.event-handler-secret-version.secret_data
   sensitive = true


### PR DESCRIPTION
Add the github parser service, pub/sub queue, and associated IAM resources to Terraform.

Note that this is far from complete, but if you run `/experimental/terraform/setup.sh`, it should run without errors.