### PR TITLE
Refactor "deployments" sql query

### DIFF
--- a/queries/deployments.sql
+++ b/queries/deployments.sql
@@ -74,6 +74,6 @@ WITH deploys_cloudbuild_github_gitlab AS (# Cloud Build, Github, Gitlab pipeline
     time_created,
     main_commit,   
     ARRAY_AGG(DISTINCT JSON_EXTRACT_SCALAR(array_commits, '$.id')) changes,    
-    FROM changes
+    FROM deployment_changes
     CROSS JOIN changes.array_commits
     GROUP BY 1,2,3,4;


### PR DESCRIPTION
- Pulled the different subqueries out into it's own WITH clauses as recommended by the BigQuery docs (please see screenshot below)
- I didn't change any of the functionality, the query still output the same result. I just found it really difficult to keep all the variables in my head because of nesting, which motivated me to refactor the query a bit.

https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#with_clause
![image](https://user-images.githubusercontent.com/12196246/118988793-cca1af00-b981-11eb-97a8-3c4996e85901.png)
