### PR TITLE
Registering the function

### DIFF
--- a/queries/json2array.sql
+++ b/queries/json2array.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE FUNCTION four_keys.json2array(json STRING)
+RETURNS ARRAY<STRING>
+LANGUAGE js AS """
+  return JSON.parse(json).map(x=>JSON.stringify(x));
+"""; 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -155,6 +155,9 @@ fourkeys_project_setup () {
     $DIR/incidents_schema.json
   set +x; echo
 
+  # Create the json2array function
+  bq query --nouse_legacy_sql $(cat ${DIR}/../queries/json2array.sql)
+
   echo "Saving Event Handler Secret in Secret Manager.."
   # Set permissions so Cloud Run can access secrets
   SERVICE_ACCOUNT="${FOURKEYS_PROJECTNUM}-compute@developer.gserviceaccount.com"


### PR DESCRIPTION
Removing the temporary function from `deployments.sql` broke the bash setup path.   Patching this in.    It didn't break the tests b/c the new SQL failed to run and did not overwrite the old table, which had data in it.   