### PR TITLE
chore: move unit tests & linting to gh actions, closes #162

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,13 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: excitedleigh/setup-nox@v2
+      - run: nox

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ terraform.rc
 # exclude terraform backend b/c different users will choose different backends
 backend.tf
 
+.idea
+*.iml

--- a/tests.cloudbuild.yaml
+++ b/tests.cloudbuild.yaml
@@ -1,7 +1,0 @@
-steps:
-  - name: gcr.io/cloud-devrel-public-resources/python-multi
-    entrypoint: /bin/bash
-    args:
-       - '-c'
-       - |
-        pip3 install nox && python3 -m nox


### PR DESCRIPTION
This is a rather simple way of doing this. We could also run eg. flake8 manually and then use some fancy GitHub Action to directly annotate files in PRs. Let me know if you want that as well :)


NB: also closes https://github.com/GoogleCloudPlatform/fourkeys/issues/143 ?