### PR TITLE
Add check on null commits array

### DIFF
--- a/queries/json2array.sql
+++ b/queries/json2array.sql
@@ -1,5 +1,9 @@
 CREATE OR REPLACE FUNCTION four_keys.json2array(json STRING)
 RETURNS ARRAY<STRING>
 LANGUAGE js AS """
-  return JSON.parse(json).map(x=>JSON.stringify(x));
-"""; 
+  if (json) {
+    return JSON.parse(json).map(x=>JSON.stringify(x));
+  } else {
+    return [];
+  }
+""";


### PR DESCRIPTION
I had an error on executing `deployments.sql`:
```
TypeError: Cannot read property 'map' of null at UDF$2(STRING) line 2, columns 23-24
```
I've found that some of our events from GCB didn't contain a `commits` array.
Adding simple `if` in `json2array` function solves the problem.