### PR TITLE
setup.sh does not work when VCS or CI/CD selection is skipped

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -127,12 +127,21 @@ else
     GENERATE_DATA="no"
 fi
 
+PARSERS=""
+for PARSER in ${GIT_SYSTEM} ${CICD_SYSTEM}; do
+    if [ "${PARSERS}" == "" ]; then
+        PARSERS="\"${PARSER}\""
+    else
+        PARSERS+=",\"${PARSER}\""
+    fi
+done
+
 # create a tfvars file
 cat > terraform.tfvars <<EOF
 google_project_id = "${FOURKEYS_PROJECT}"
 google_region = "${FOURKEYS_REGION}"
 bigquery_region = "${BIGQUERY_REGION}"
-parsers = ["${GIT_SYSTEM}","${CICD_SYSTEM}"]
+parsers = [${PARSERS}]
 EOF
 
 echo "••••••••🔑••🔑••🔑••🔑••••••••"


### PR DESCRIPTION
## Problem

The following error will occur in the situation described in the title.

```sh
│ Error: Error creating Service: googleapi: Error 400: metadata.name: Resource name must use only lowercase letters, numbers and '-'. Must begin with a letter and cannot end with a '-'. Maximum length is 63 characters.
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.BadRequest",
│     "fieldViolations": [
│       {
│         "description": "Resource name must use only lowercase letters, numbers and '-'. Must begin with a letter and cannot end with a '-'. Maximum length is 63 characters.",
│         "field": "metadata.name"
│       }
│     ]
│   }
│ ]
│
│   with module.data_parser_service[""].google_cloud_run_service.parser,
│   on data_parser/main.tf line 1, in resource "google_cloud_run_service" "parser":
│    1: resource "google_cloud_run_service" "parser" {
```

## Reproduction

For example, it will reproduce if you select github for VCS and Other for CD/CD.

```sh
$ ./setup.sh --clean 2>&1 | tee setup.log
Would you like to create a new project for The Four Keys (y/N): n

Which version control system are you using?
    (1) GitLab
    (2) GitHub
    (3) Other

    Enter a selection (1 - 3): 2

    Which CI/CD system are you using?
    (1) Cloud Build
    (2) Tekton
    (3) GitLab
    (4) Other

    Enter a selection (1 - 4): 4

Would you like to generate mock data? (y/N): y
Enter the project ID for Four Keys installation (ex: 'my-project'): my-project
Enter the region for Four Keys resources (ex: 'us-central1'): us-central1
Enter the location for Four Keys BigQuery resources ('US' or 'EU'): US
```

## Fixed

The reason is that an empty element is added to parsers of `terraform.tfvars`, which results in the generation of an empty resource. For example, if CI/CD is not selected, the following `terraform.tfvars` will be generated.


```setup/terraform.tfvars
google_project_id = "my-project"
google_region = "us-central1"
bigquery_region = "US"
parsers = ["github",""]
```

Fixed it so that it doesn't add empty element when skipping and I have confirmed that it works correctly in my environment. For example, if CI/CD is not selected, the following `terraform.tfvars` will be generated.

```setup/terraform.tfvars
google_project_id = "my-project"
google_region = "us-central1"
bigquery_region = "US"
parsers = ["github"]
```

