### PR TITLE
Fix the query to generate the changes view

### DIFF
--- a/queries/changes.sql
+++ b/queries/changes.sql
@@ -6,5 +6,5 @@ JSON_EXTRACT_SCALAR(commit, '$.id') change_id,
 TIMESTAMP_TRUNC(TIMESTAMP(JSON_EXTRACT_SCALAR(commit, '$.timestamp')),second) as time_created,
 FROM four_keys.events_raw e,
 UNNEST(JSON_EXTRACT_ARRAY(e.metadata, '$.commits')) as commit
-WHERE event_type in ("pull_request", "push", "merge_request")
+WHERE event_type = "push"
 GROUP BY 1,2,3,4


### PR DESCRIPTION
## Why

I think Event Type `pull_request` and `merge_request` are the following webhook events.

- GitHub: [pull_request](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request)
- GitLab: [merge_request](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#merge-request-events)

According to their specification documents, the payload does not contain a `commits` field. In the query to generate the `changes` view, `UNNEST(JSON_EXTRACT_ARRAY(e.metadata, '$.commits')` is executed. 

However, event_type `pull_request` and `merge_request` are excluded by the `UNNEST` function because they don't have `commits` field for the reason mentioned above.

## Relation

The query that considers the `metadata.commits` field in the `events_raw` table was changed in PR #132. Before PR #132, the id of event_type `pull_request` and `merge_request` were shown as `change_id` in the `changes` view. 

However, the id of event_type `pull_request` and `merge_request` are formatted as `$repository_name/$number`, which does not represent the SHA of the commit. Also, the metadata for the event_type `pull_request` and `merge_request` does not have a field representing the SHA of the commit. 

So we can change the query that builds the changes view to target only event_type `push`, instead of treating it as before PR #132. Please advise me if my understanding is wrong.