### PR TITLE
Add deployment events to gitlab-parser

### DIFF
--- a/bq-workers/gitlab-parser/main.py
+++ b/bq-workers/gitlab-parser/main.py
@@ -76,7 +76,10 @@ def process_gitlab_event(headers, msg):
     if "Mock" in headers:
         source += "mock"
 
-    types = {"push", "merge_request", "note", "tag_push", "issue", "pipeline", "job", "deployment"}
+    types = {"push", "merge_request", 
+             "note", "tag_push", "issue", 
+             "pipeline", "job", "deployment",
+             "build"}
 
     metadata = json.loads(base64.b64decode(msg["data"]).decode("utf-8").strip())
 
@@ -107,7 +110,17 @@ def process_gitlab_event(headers, msg):
         
     if event_type in ("deployment"):
         e_id = metadata["deployment_id"]
-        time_created = metadata["status_changed_at"]
+        # Deployment timestamps come in a format like "2021-04-28 21:50:00 +0200"
+        # BigQuery does not accept this as a valid format 
+        # Removing the extra timezone information below
+        time_created = metadata["status_changed_at"][:-6]
+
+    if event_type in ("build"):
+        e_id = metadata["build_id"]
+        time_created = (
+            metadata.get("build_finished_at") or
+            metadata.get("build_started_at") or
+            metadata.get("build_created_at"))
 
     gitlab_event = {
         "event_type": event_type,

--- a/bq-workers/gitlab-parser/main.py
+++ b/bq-workers/gitlab-parser/main.py
@@ -76,7 +76,7 @@ def process_gitlab_event(headers, msg):
     if "Mock" in headers:
         source += "mock"
 
-    types = {"push", "merge_request", "note", "tag_push", "issue", "pipeline", "job"}
+    types = {"push", "merge_request", "note", "tag_push", "issue", "pipeline", "job", "deployment"}
 
     metadata = json.loads(base64.b64decode(msg["data"]).decode("utf-8").strip())
 
@@ -104,6 +104,10 @@ def process_gitlab_event(headers, msg):
         time_created = (
             event_object.get("finished_at") or
             event_object.get("started_at"))
+        
+    if event_type in ("deployment"):
+        e_id = metadata["deployment_id"]
+        time_created = metadata["status_changed_at"]
 
     gitlab_event = {
         "event_type": event_type,

--- a/bq-workers/gitlab-parser/main.py
+++ b/bq-workers/gitlab-parser/main.py
@@ -76,8 +76,8 @@ def process_gitlab_event(headers, msg):
     if "Mock" in headers:
         source += "mock"
 
-    types = {"push", "merge_request", 
-             "note", "tag_push", "issue", 
+    types = {"push", "merge_request",
+             "note", "tag_push", "issue",
              "pipeline", "job", "deployment",
              "build"}
 
@@ -107,11 +107,11 @@ def process_gitlab_event(headers, msg):
         time_created = (
             event_object.get("finished_at") or
             event_object.get("started_at"))
-        
+
     if event_type in ("deployment"):
         e_id = metadata["deployment_id"]
         # Deployment timestamps come in a format like "2021-04-28 21:50:00 +0200"
-        # BigQuery does not accept this as a valid format 
+        # BigQuery does not accept this as a valid format
         # Removing the extra timezone information below
         time_created = metadata["status_changed_at"][:-6]
 

--- a/bq-workers/gitlab-parser/main_test.py
+++ b/bq-workers/gitlab-parser/main_test.py
@@ -93,3 +93,42 @@ def test_gitlab_event_processed(client):
 
     shared.insert_row_into_bigquery.assert_called_with(event)
     assert r.status_code == 204
+
+
+def test_deployment_event_processed(client):
+    headers = {"X-Gitlab-Event": "deployment", "X-Gitlab-Token": "foo"}
+    data = json.dumps({"object_kind": "deployment",
+                       "short_sha": "279484c0",
+                       "status_changed_at": "2021-04-28 21:50:00 +0200",
+                       "deployment_id": 15,
+                        }).encode("utf-8")
+
+    pubsub_msg = {
+        "message": {
+            "data": base64.b64encode(data).decode("utf-8"),
+            "attributes": {"headers": json.dumps(headers)},
+            "message_id": "foobar",
+            "publishTime": 1,
+        },
+    }
+
+    event = {
+        "event_type": "deployment",
+        "id": 15,
+        "metadata": data.decode(),
+        "time_created": "2021-04-28 21:50:00",
+        "signature": shared.create_unique_id(pubsub_msg["message"]),
+        "msg_id": "foobar",
+        "source": "gitlab",
+    }
+
+    shared.insert_row_into_bigquery = mock.MagicMock()
+
+    r = client.post(
+        "/",
+        data=json.dumps(pubsub_msg),
+        headers={"Content-Type": "application/json"},
+    )
+
+    shared.insert_row_into_bigquery.assert_called_with(event)
+    assert r.status_code == 204

--- a/bq-workers/gitlab-parser/main_test.py
+++ b/bq-workers/gitlab-parser/main_test.py
@@ -101,7 +101,7 @@ def test_deployment_event_processed(client):
                        "short_sha": "279484c0",
                        "status_changed_at": "2021-04-28 21:50:00 +0200",
                        "deployment_id": 15,
-                        }).encode("utf-8")
+                       }).encode("utf-8")
 
     pubsub_msg = {
         "message": {


### PR DESCRIPTION
Updating to include https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#deployment-events

Should also update the data generator to include deployment events instead of pipeline events as deployments