### PR TITLE
Fix lead time for changes query on grafana dashboard

### DIFF
--- a/dashboard/fourkeys_dashboard.json
+++ b/dashboard/fourkeys_dashboard.json
@@ -101,7 +101,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "SElECT\nday,\nPERCENTILE_CONT(\n  # Ignore automated changes\n  IF(time_to_change_minutes > 0,time_to_change_minutes, NULL), \n  0.5) # Median\n  OVER (partition by day)/50 median_time_to_change\nFROM\n(SELECT\n d.deploy_id,\n TIMESTAMP_TRUNC(d.time_created, DAY) as day,\n # Time to Change\n TIMESTAMP_DIFF(d.time_created, c.time_created, MINUTE) time_to_change_minutes\n FROM four_keys.deployments d, d.changes\n LEFT JOIN four_keys.changes c ON changes = c.change_id\n )\nGROUP BY day, time_to_change_minutes\nORDER BY day",
+          "rawSql": "SELECT\n day,\n IFNULL(ANY_VALUE(med_time_to_change)/60, 0) AS median_time_to_change, # Hours\nFROM (\n SELECT\n  d.deploy_id,\n  TIMESTAMP_TRUNC(d.time_created, DAY) AS day,\n  PERCENTILE_CONT(\n  IF(TIMESTAMP_DIFF(d.time_created, c.time_created, MINUTE) > 0, TIMESTAMP_DIFF(d.time_created, c.time_created, MINUTE), NULL), # Ignore automated pushes\n  0.5) # Median\n  OVER (PARTITION BY TIMESTAMP_TRUNC(d.time_created, DAY)) AS med_time_to_change, # Minutes\n FROM four_keys.deployments d, d.changes\n LEFT JOIN four_keys.changes c ON changes = c.change_id\n)\nGROUP BY day",
           "refId": "A",
           "select": [
             [

--- a/dashboard/fourkeys_dashboard.json
+++ b/dashboard/fourkeys_dashboard.json
@@ -101,7 +101,7 @@
           "orderByCol": "1",
           "orderBySort": "1",
           "rawQuery": true,
-          "rawSql": "SELECT\n day,\n IFNULL(ANY_VALUE(med_time_to_change)/60, 0) AS median_time_to_change, # Hours\nFROM (\n SELECT\n  d.deploy_id,\n  TIMESTAMP_TRUNC(d.time_created, DAY) AS day,\n  PERCENTILE_CONT(\n  IF(TIMESTAMP_DIFF(d.time_created, c.time_created, MINUTE) > 0, TIMESTAMP_DIFF(d.time_created, c.time_created, MINUTE), NULL), # Ignore automated pushes\n  0.5) # Median\n  OVER (PARTITION BY TIMESTAMP_TRUNC(d.time_created, DAY)) AS med_time_to_change, # Minutes\n FROM four_keys.deployments d, d.changes\n LEFT JOIN four_keys.changes c ON changes = c.change_id\n)\nGROUP BY day",
+          "rawSql": "SELECT\n day,\n IFNULL(ANY_VALUE(med_time_to_change)/60, 0) AS median_time_to_change, # Hours\nFROM (\n SELECT\n  d.deploy_id,\n  TIMESTAMP_TRUNC(d.time_created, DAY) AS day,\n  PERCENTILE_CONT(\n  IF(TIMESTAMP_DIFF(d.time_created, c.time_created, MINUTE) > 0, TIMESTAMP_DIFF(d.time_created, c.time_created, MINUTE), NULL), # Ignore automated pushes\n  0.5) # Median\n  OVER (PARTITION BY TIMESTAMP_TRUNC(d.time_created, DAY)) AS med_time_to_change, # Minutes\n FROM four_keys.deployments d, d.changes\n LEFT JOIN four_keys.changes c ON changes = c.change_id\n)\nGROUP BY day\nORDER BY day",
           "refId": "A",
           "select": [
             [


### PR DESCRIPTION
## About

The results of the previous DataStudio dashboard and the Grafana dashboard are different; the query in Grafana Dashboard may be wrong. I used DataStudio connector's query as a reference and changed it to a query that gives the same results. If you have intentionally changed it, please let me know.

https://github.com/GoogleCloudPlatform/fourkeys/blob/6bb4ef0eee045e580d1790b0994226f89538dabc/connector/data.gs#L69-L129

## Change

Before

- I don't understand the intention of `... OVER (partition by day)/50`. If convert minutes to hours, it may be 60 ?
- `GROUP BY day, time_to_change_minutes` changed the calculation for records with the same value of time_to_change_minutes. This will change the median. Is this an intended change ?

```sql
SElECT
 day,
 PERCENTILE_CONT(
  # Ignore automated changes
  IF(time_to_change_minutes > 0, time_to_change_minutes, NULL),
  0.5) # Median
  OVER (partition by day)/50 median_time_to_change
FROM (
 SELECT
  d.deploy_id,
  TIMESTAMP_TRUNC(d.time_created, DAY) as day,
  # Time to Change
  TIMESTAMP_DIFF(d.time_created, c.time_created, MINUTE) time_to_change_minutes
 FROM four_keys.deployments d, d.changes
 LEFT JOIN four_keys.changes c ON changes = c.change_id
)
GROUP BY day, time_to_change_minutes
ORDER BY day
```

After

- Convert minutes to hours
- Remove time_to_change_minutes from `GROUP BY`

```sql
SELECT
 day,
 IFNULL(ANY_VALUE(med_time_to_change)/60, 0) AS median_time_to_change, # Hours
FROM (
 SELECT
  d.deploy_id,
  TIMESTAMP_TRUNC(d.time_created, DAY) AS day,
  PERCENTILE_CONT(
   IF(TIMESTAMP_DIFF(d.time_created, c.time_created, MINUTE) > 0, TIMESTAMP_DIFF(d.time_created, c.time_created, MINUTE), NULL), # Ignore automated pushes
   0.5) # Median
   OVER (PARTITION BY TIMESTAMP_TRUNC(d.time_created, DAY)) AS med_time_to_change, # Minutes
 FROM four_keys.deployments d, d.changes
 LEFT JOIN four_keys.changes c ON changes = c.change_id
)
GROUP BY day
ORDER BY day
```


## Outstanding questions

If I understand correctly, the [query to calculate the Lead Time for Changes bucket](https://github.com/GoogleCloudPlatform/fourkeys/blob/f460e5e413f61ac23571e3856e755ab61336bf10/dashboard/fourkeys_dashboard.json#L204) and [METRICS.md](https://github.com/GoogleCloudPlatform/fourkeys/blob/main/METRICS.md#lead-time-for-changes) need to be modified. I have not included those fixes in this PR because I would like to discuss whether this fix is correct.