### PR TITLE
Adding CloudEvents to the Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ Non-goals:
     * New data views for drilling down into the metrics
 * Long Term
   * CloudEvents migration 
-    * Migrate the `four_keys.events_raw` schema to CloudEvents schema
+    * Migrate the `four_keys.events_raw` schema to [CloudEvents](https://github.com/cloudevents/spec) schema
     * Use the CloudEvents adapters to do the ETL rather than the current [workers](bq-workers/)
   * New Integrations
     * CI/CD Tools

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,6 +25,9 @@ Non-goals:
     * [More data points](https://github.com/GoogleCloudPlatform/fourkeys/issues/77)
     * New data views for drilling down into the metrics
 * Long Term
+  * CloudEvents migration 
+    * Migrate the `four_keys.events_raw` schema to CloudEvents schema
+    * Use the CloudEvents adapters to do the ETL rather than the current (parsers)[bq-workers/]
   * New Integrations
     * CI/CD Tools
       * [Jenkins](https://www.jenkins.io/)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ Non-goals:
 * Long Term
   * CloudEvents migration 
     * Migrate the `four_keys.events_raw` schema to CloudEvents schema
-    * Use the CloudEvents adapters to do the ETL rather than the current (parsers)[bq-workers/]
+    * Use the CloudEvents adapters to do the ETL rather than the current [workers](bq-workers/)
   * New Integrations
     * CI/CD Tools
       * [Jenkins](https://www.jenkins.io/)


### PR DESCRIPTION
If we can use CloudEvents for the data schema, we'd have greater extensibility and we could rely on their adapters rather than maintain our ETL logic. 