### PR TITLE
Update daily deployments dashboard graph

### DIFF
--- a/dashboard/fourkeys_dashboard.json
+++ b/dashboard/fourkeys_dashboard.json
@@ -239,7 +239,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "bars",
-            "fillOpacity": 0,
+            "fillOpacity": 50,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -263,6 +263,7 @@
             }
           },
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [


### PR DESCRIPTION
## About

Small fixes for daily deployments dashboard graph

- set fill opacity 
- set min

## Before

![image](https://user-images.githubusercontent.com/537006/134297357-1e54077f-894e-4cdc-8d44-0a5b88de887b.png)

## After 

![image](https://user-images.githubusercontent.com/537006/134297336-d853d60f-69ec-4614-83c6-d05dd3b1fe4d.png)
