### PR TITLE
Enabled timepicker in grafana dashboard

### DIFF
--- a/dashboard/fourkeys_dashboard.json
+++ b/dashboard/fourkeys_dashboard.json
@@ -859,7 +859,7 @@
     "to": "now"
   },
   "timepicker": {
-    "hidden": true,
+    "hidden": false,
     "refresh_intervals": [
       "5s",
       "10s",


### PR DESCRIPTION
## Why

Useful for displaying metrics for a specified time period

## Before

![image](https://user-images.githubusercontent.com/537006/134302625-e22a2a6b-3b0a-48c4-8af1-936a19e647b1.png)

## After

![image](https://user-images.githubusercontent.com/537006/134302662-4b59794d-d889-417b-bf2c-680e4ca8f5ad.png)


