### PR TITLE
Enabled shared tooltip in grafana dashboard

### DIFF
--- a/dashboard/fourkeys_dashboard.json
+++ b/dashboard/fourkeys_dashboard.json
@@ -20,7 +20,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 2,
   "id": 1,
   "links": [],
   "panels": [


### PR DESCRIPTION
## About

Select "Shared Tooltip" for the graph tooltip panel option of the dashboard.

![image](https://user-images.githubusercontent.com/537006/134314793-2c1676cc-beaf-4580-a1ed-8d794f9a8dce.png)

## Before

The cursor will only appear on the graph you are mouse-over.

![image](https://user-images.githubusercontent.com/537006/134314456-9d5975c3-ee3c-4fcb-937d-09ddbbcdfdc8.png)

## After

The cursor will appear on all graphs, making it easier to compare them at the same time.

![image](https://user-images.githubusercontent.com/537006/134314071-9a3aebd9-dd4c-44e3-9d3e-081cca4adbc5.png)
