### PR TITLE
Fix time_created on cloud build event

### DIFF
--- a/bq-workers/cloud-build-parser/main.py
+++ b/bq-workers/cloud-build-parser/main.py
@@ -74,12 +74,7 @@ def process_cloud_build_event(attr, msg):
     metadata = json.loads(base64.b64decode(msg["data"]).decode("utf-8").strip())
 
     # Most up to date timestamp for the event
-    if "finishTime" in metadata:
-        time_created = metadata["finishTime"]
-    if "startTime" in metadata:
-        time_created = metadata["startTime"]
-    if "createTime" in metadata:
-        time_created = metadata["createTime"]
+    time_created = (metadata.get("finishTime") or metadata.get("startTime") or metadata.get("createTime"))
 
     build_event = {
         "event_type": event_type,

--- a/bq-workers/cloud-build-parser/main_test.py
+++ b/bq-workers/cloud-build-parser/main_test.py
@@ -58,7 +58,7 @@ def test_missing_msg_attributes(client):
 
 
 def test_cloud_build_event_processed(client):
-    data = json.dumps({"startTime":  0}).encode("utf-8")
+    data = json.dumps({"createTime": 1, "startTime": 2, "finishTime": 3}).encode("utf-8")
     pubsub_msg = {
         "message": {
             "data": base64.b64encode(data).decode("utf-8"),
@@ -70,8 +70,8 @@ def test_cloud_build_event_processed(client):
     build_event = {
         "event_type": "build",
         "id": "foo",
-        "metadata": '{"startTime": 0}',
-        "time_created": 0,
+        "metadata": '{"createTime": 1, "startTime": 2, "finishTime": 3}',
+        "time_created": 3,
         "signature": shared.create_unique_id(pubsub_msg["message"]),
         "msg_id": "foobar",
         "source": "cloud_build",


### PR DESCRIPTION
The current implementation appears to use the old date of the event, but looking at the [comment](https://github.com/GoogleCloudPlatform/fourkeys/blob/94b15f2002525ce5eace16d5db99d0dae2dd1acc/bq-workers/cloud-build-parser/main.py#L76) and [other parser implementations](https://github.com/GoogleCloudPlatform/fourkeys/blob/94b15f2002525ce5eace16d5db99d0dae2dd1acc/bq-workers/gitlab-parser/main.py#L120-L123) it looks correct to use the most up to date.