### PR TITLE
Try / except for timestamp conversion

### DIFF
--- a/bq-workers/gitlab-parser/main.py
+++ b/bq-workers/gitlab-parser/main.py
@@ -127,7 +127,7 @@ def process_gitlab_event(headers, msg):
         dt = datetime.strptime(time_created, '%Y-%m-%d %H:%M:%S %z')
         time_created = dt.strftime('%Y-%m-%d %H:%M:%S')
 
-    # If the timestamp is not parsed correctly, 
+    # If the timestamp is not parsed correctly,
     # we will default to the string from the event payload
     except Exception:
         pass

--- a/bq-workers/gitlab-parser/main.py
+++ b/bq-workers/gitlab-parser/main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import base64
+from datetime import datetime
 import os
 import json
 
@@ -110,10 +111,7 @@ def process_gitlab_event(headers, msg):
 
     if event_type in ("deployment"):
         e_id = metadata["deployment_id"]
-        # Deployment timestamps come in a format like "2021-04-28 21:50:00 +0200"
-        # BigQuery does not accept this as a valid format
-        # Removing the extra timezone information below
-        time_created = metadata["status_changed_at"][:-6]
+        time_created = metadata["status_changed_at"]
 
     if event_type in ("build"):
         e_id = metadata["build_id"]
@@ -121,6 +119,18 @@ def process_gitlab_event(headers, msg):
             metadata.get("build_finished_at") or
             metadata.get("build_started_at") or
             metadata.get("build_created_at"))
+
+    # Some timestamps come in a format like "2021-04-28 21:50:00 +0200"
+    # BigQuery does not accept this as a valid format
+    # Removing the extra timezone information below
+    try:
+        dt = datetime.strptime(time_created, '%Y-%m-%d %H:%M:%S %z')
+        time_created = dt.strftime('%Y-%m-%d %H:%M:%S')
+
+    # If the timestamp is not parsed correctly, 
+    # we will default to the string from the event payload
+    except Exception:
+        pass
 
     gitlab_event = {
         "event_type": event_type,

--- a/bq-workers/gitlab-parser/main_test.py
+++ b/bq-workers/gitlab-parser/main_test.py
@@ -95,7 +95,7 @@ def test_gitlab_event_processed(client):
     assert r.status_code == 204
 
 
-def test_deployment_event_processed(client):
+def test_timestamp_timezone_event_processed(client):
     headers = {"X-Gitlab-Event": "deployment", "X-Gitlab-Token": "foo"}
     data = json.dumps({"object_kind": "deployment",
                        "short_sha": "279484c0",


### PR DESCRIPTION
Some timestamps from Gitlab now include timezone information.  BigQuery does not natively handle these as timestamps.  

Now, the parser will attempt to convert the string from a timezone string into a non-timezone string.  If it doesn't have a timezone in it, it will simply keep the previous string and insert it into BigQuery.