### PR TITLE
Split Parser Module

### DIFF
--- a/experimental/terraform/example/main.tf
+++ b/experimental/terraform/example/main.tf
@@ -10,6 +10,7 @@ terraform {
 module "fourkeys" {
   source = "../modules/fourkeys"
   project_id = var.project_id
+  enable_apis = true
   region = var.region
   bigquery_region = var.bigquery_region
   parsers = var.parsers

--- a/experimental/terraform/modules/fourkeys-bigquery/main.tf
+++ b/experimental/terraform/modules/fourkeys-bigquery/main.tf
@@ -5,6 +5,7 @@ locals {
 }
 
 resource "google_project_service" "bigquery_services" {
+  project                    = var.project_id
   for_each                   = toset(local.services)
   service                    = each.value
   disable_on_destroy         = false

--- a/experimental/terraform/modules/fourkeys-cloud-build-parser/main.tf
+++ b/experimental/terraform/modules/fourkeys-cloud-build-parser/main.tf
@@ -1,0 +1,77 @@
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+locals {
+    services = var.enable_apis ? [
+    "run.googleapis.com"
+  ] : []
+}
+
+resource "google_project_service" "data_source_services" {
+  project                    = var.project_id
+  for_each                   = toset(local.services)
+  service                    = each.value
+  disable_on_destroy         = false
+}
+
+resource "google_cloud_run_service" "cloudbuild_parser" {
+  project  = var.project_id
+  name     = "fourkeys-cloudbuild-parser"
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = var.parser_container_url
+        env {
+          name  = "PROJECT_NAME"
+          value = var.project_id
+        }
+      }
+      service_account_name = var.fourkeys_service_account_email
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  autogenerate_revision_name = true
+  depends_on = [
+    google_project_service.data_source_services
+  ]
+}
+
+resource "google_pubsub_topic" "cloudbuild" {
+  project = var.project_id
+  name    = "fourkeys-cloudbuild"
+}
+
+resource "google_pubsub_topic_iam_member" "service_account_editor" {
+  project = var.project_id
+  topic   = google_pubsub_topic.cloudbuild.id
+  role    = "roles/editor"
+  member  = "serviceAccount:${var.fourkeys_service_account_email}"
+}
+
+resource "google_pubsub_subscription" "cloudbuild" {
+  project = var.project_id
+  name    = "fourkeys-cloudbuild"
+  topic   = google_pubsub_topic.cloudbuild.id
+
+  push_config {
+    push_endpoint = google_cloud_run_service.cloudbuild_parser.status[0]["url"]
+
+    oidc_token {
+      service_account_email = var.fourkeys_service_account_email
+    }
+  }
+}
+
+resource "google_project_iam_member" "pubsub_service_account_token_creator" {
+  project = var.project_id
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+  role    = "roles/iam.serviceAccountTokenCreator"
+}

--- a/experimental/terraform/modules/fourkeys-cloud-build-parser/variables.tf
+++ b/experimental/terraform/modules/fourkeys-cloud-build-parser/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  type = string
+  description = "Project ID of the target project."
+}
+
+variable "region" {
+  type    = string
+  description = "Region to deploy resources."
+  default = "us-central1"
+}
+
+variable "fourkeys_service_account_email" {
+  type = string
+  description = "Service account for fourkeys."
+}
+
+variable "enable_apis" {
+  type        = bool
+  description = "Toggle to include required APIs."
+  default     = false
+}
+
+variable "parser_container_url" {
+  type = string
+  description = "URL of image to use in Cloud Run service configuration."
+}

--- a/experimental/terraform/modules/fourkeys-foundation/main.tf
+++ b/experimental/terraform/modules/fourkeys-foundation/main.tf
@@ -14,6 +14,7 @@ locals {
 
 ## Services
 resource "google_project_service" "foundation_services" {
+  project                    = var.project_id
   for_each                   = toset(local.services)
   service                    = each.value
   disable_on_destroy         = false

--- a/experimental/terraform/modules/fourkeys-github-parser/main.tf
+++ b/experimental/terraform/modules/fourkeys-github-parser/main.tf
@@ -1,7 +1,3 @@
-data "google_project" "project" {
-  project_id = var.project_id
-}
-
 locals {
     services = var.enable_apis ? [
     "run.googleapis.com"
@@ -67,10 +63,4 @@ resource "google_pubsub_subscription" "github" {
       service_account_email = var.fourkeys_service_account_email
     }
   }
-}
-
-resource "google_project_iam_member" "pubsub_service_account_token_creator" {
-  project = var.project_id
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-  role    = "roles/iam.serviceAccountTokenCreator"
 }

--- a/experimental/terraform/modules/fourkeys-github-parser/main.tf
+++ b/experimental/terraform/modules/fourkeys-github-parser/main.tf
@@ -1,0 +1,76 @@
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+locals {
+    services = var.enable_apis ? [
+    "run.googleapis.com"
+  ] : []
+}
+
+resource "google_project_service" "data_source_services" {
+  for_each                   = toset(local.services)
+  service                    = each.value
+  disable_on_destroy         = false
+}
+
+resource "google_cloud_run_service" "github_parser" {
+  project  = var.project_id
+  name     = "fourkeys-github-parser"
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = var.parser_container_url
+        env {
+          name  = "PROJECT_NAME"
+          value = var.project_id
+        }
+      }
+      service_account_name = var.fourkeys_service_account_email
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  autogenerate_revision_name = true
+  depends_on = [
+    google_project_service.data_source_services
+  ]
+}
+
+resource "google_pubsub_topic" "github" {
+  project = var.project_id
+  name    = "fourkeys-github"
+}
+
+resource "google_pubsub_topic_iam_member" "service_account_editor" {
+  project = var.project_id
+  topic   = google_pubsub_topic.github.id
+  role    = "roles/editor"
+  member  = "serviceAccount:${var.fourkeys_service_account_email}"
+}
+
+resource "google_pubsub_subscription" "github" {
+  project = var.project_id
+  name    = "fourkeys-github"
+  topic   = google_pubsub_topic.github.id
+
+  push_config {
+    push_endpoint = google_cloud_run_service.github_parser.status[0]["url"]
+
+    oidc_token {
+      service_account_email = var.fourkeys_service_account_email
+    }
+  }
+}
+
+resource "google_project_iam_member" "pubsub_service_account_token_creator" {
+  project = var.project_id
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+  role    = "roles/iam.serviceAccountTokenCreator"
+}

--- a/experimental/terraform/modules/fourkeys-github-parser/main.tf
+++ b/experimental/terraform/modules/fourkeys-github-parser/main.tf
@@ -1,3 +1,7 @@
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
 locals {
     services = var.enable_apis ? [
     "run.googleapis.com"
@@ -5,6 +9,7 @@ locals {
 }
 
 resource "google_project_service" "data_source_services" {
+  project                    = var.project_id
   for_each                   = toset(local.services)
   service                    = each.value
   disable_on_destroy         = false

--- a/experimental/terraform/modules/fourkeys-github-parser/main.tf
+++ b/experimental/terraform/modules/fourkeys-github-parser/main.tf
@@ -69,3 +69,9 @@ resource "google_pubsub_subscription" "github" {
     }
   }
 }
+
+resource "google_project_iam_member" "pubsub_service_account_token_creator" {
+  project = var.project_id
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+  role    = "roles/iam.serviceAccountTokenCreator"
+}

--- a/experimental/terraform/modules/fourkeys-github-parser/variables.tf
+++ b/experimental/terraform/modules/fourkeys-github-parser/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  type = string
+  description = "Project ID of the target project."
+}
+
+variable "region" {
+  type    = string
+  description = "Region to deploy resources."
+  default = "us-central1"
+}
+
+variable "fourkeys_service_account_email" {
+  type = string
+  description = "Service account for fourkeys."
+}
+
+variable "enable_apis" {
+  type        = bool
+  description = "Toggle to include required APIs."
+  default     = false
+}
+
+variable "parser_container_url" {
+  type = string
+  description = "URL of image to use in Cloud Run service configuration."
+}

--- a/experimental/terraform/modules/fourkeys-gitlab-parser/main.tf
+++ b/experimental/terraform/modules/fourkeys-gitlab-parser/main.tf
@@ -69,3 +69,9 @@ resource "google_pubsub_subscription" "gitlab" {
     }
   }
 }
+
+resource "google_project_iam_member" "pubsub_service_account_token_creator" {
+  project = var.project_id
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+  role    = "roles/iam.serviceAccountTokenCreator"
+}

--- a/experimental/terraform/modules/fourkeys-gitlab-parser/main.tf
+++ b/experimental/terraform/modules/fourkeys-gitlab-parser/main.tf
@@ -1,3 +1,7 @@
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
 locals {
     services = var.enable_apis ? [
     "run.googleapis.com"
@@ -5,6 +9,7 @@ locals {
 }
 
 resource "google_project_service" "data_source_services" {
+  project                    = var.project_id
   for_each                   = toset(local.services)
   service                    = each.value
   disable_on_destroy         = false

--- a/experimental/terraform/modules/fourkeys-gitlab-parser/main.tf
+++ b/experimental/terraform/modules/fourkeys-gitlab-parser/main.tf
@@ -1,0 +1,66 @@
+locals {
+    services = var.enable_apis ? [
+    "run.googleapis.com"
+  ] : []
+}
+
+resource "google_project_service" "data_source_services" {
+  for_each                   = toset(local.services)
+  service                    = each.value
+  disable_on_destroy         = false
+}
+
+resource "google_cloud_run_service" "gitlab_parser" {
+  project  = var.project_id
+  name     = "fourkeys-gitlab-parser"
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = var.parser_container_url
+        env {
+          name  = "PROJECT_NAME"
+          value = var.project_id
+        }
+      }
+      service_account_name = var.fourkeys_service_account_email
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  autogenerate_revision_name = true
+  depends_on = [
+    google_project_service.data_source_services
+  ]
+}
+
+resource "google_pubsub_topic" "gitlab" {
+  project = var.project_id
+  name    = "fourkeys-gitlab"
+}
+
+resource "google_pubsub_topic_iam_member" "service_account_editor" {
+  project = var.project_id
+  topic   = google_pubsub_topic.gitlab.id
+  role    = "roles/editor"
+  member  = "serviceAccount:${var.fourkeys_service_account_email}"
+}
+
+resource "google_pubsub_subscription" "gitlab" {
+  project = var.project_id
+  name    = "fourkeys-gitlab"
+  topic   = google_pubsub_topic.gitlab.id
+
+  push_config {
+    push_endpoint = google_cloud_run_service.gitlab_parser.status[0]["url"]
+
+    oidc_token {
+      service_account_email = var.fourkeys_service_account_email
+    }
+  }
+}

--- a/experimental/terraform/modules/fourkeys-gitlab-parser/variables.tf
+++ b/experimental/terraform/modules/fourkeys-gitlab-parser/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  type = string
+  description = "Project ID of the target project."
+}
+
+variable "region" {
+  type    = string
+  description = "Region to deploy resources."
+  default = "us-central1"
+}
+
+variable "fourkeys_service_account_email" {
+  type = string
+  description = "Service account for fourkeys."
+}
+
+variable "enable_apis" {
+  type        = bool
+  description = "Toggle to include required APIs."
+  default     = false
+}
+
+variable "parser_container_url" {
+  type = string
+  description = "URL of image to use in Cloud Run service configuration."
+}

--- a/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/Dockerfile
+++ b/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/Dockerfile
@@ -1,1 +1,39 @@
-../../../../../../../bq-workers/cloud-build-parser/Dockerfile
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Use the official Python image.
+# https://hub.docker.com/_/python
+FROM python:3.7
+
+# Allow statements and log messages to immediately appear in the Cloud Run logs
+ENV PYTHONUNBUFFERED True
+
+# Copy application dependency manifests to the container image.
+# Copying this separately prevents re-running pip install on every code change.
+COPY requirements.txt .
+
+# Install production dependencies.
+RUN pip install -r requirements.txt
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . .
+
+# Run the web service on container startup.
+# Use gunicorn webserver with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/cloudbuild.yaml
+++ b/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/cloudbuild.yaml
@@ -1,1 +1,40 @@
-../../../../../../../bq-workers/cloud-build-parser/cloudbuild.yaml
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- # Build cloud-build-parser image
+  name: gcr.io/cloud-builders/docker:latest
+  args: ['build', 
+         '--tag=gcr.io/$PROJECT_ID/cloud-build-parser:${_TAG}', '.']
+  id: build
+
+- # Push the container image to Container Registry
+  name: gcr.io/cloud-builders/docker
+  args: ['push', 'gcr.io/$PROJECT_ID/cloud-build-parser:${_TAG}']
+  waitFor: build
+  id: push
+
+- # Deploy to Cloud Run
+  name: google/cloud-sdk
+  args: ['gcloud', 'run', 'deploy', 'cloud-build-parser',
+         '--image', 'gcr.io/$PROJECT_ID/cloud-build-parser:${_TAG}',
+         '--region', '${_REGION}',
+         '--platform', 'managed'
+  ]
+  id: deploy
+  waitFor: push
+
+images: [
+  'gcr.io/$PROJECT_ID/cloud-build-parser:${_TAG}'
+]

--- a/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/main.py
+++ b/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/main.py
@@ -1,1 +1,97 @@
-../../../../../../../bq-workers/cloud-build-parser/main.py
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import os
+import json
+
+import shared
+
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+@app.route("/", methods=["POST"])
+def index():
+    """
+    Receives messages from a push subscription from Pub/Sub.
+    Parses the message, and inserts it into BigQuery.
+    """
+    event = None
+    envelope = request.get_json()
+
+    # Check that data has been posted
+    if not envelope:
+        raise Exception("Expecting JSON payload")
+    # Check that message is a valid pub/sub message
+    if "message" not in envelope:
+        raise Exception("Not a valid Pub/Sub Message")
+    msg = envelope["message"]
+
+    if "attributes" not in msg:
+        raise Exception("Missing pubsub attributes")
+
+    try:
+        attr = msg["attributes"]
+        # Process Cloud Build event
+        if "buildId" in attr:
+            event = process_cloud_build_event(attr, msg)
+
+        shared.insert_row_into_bigquery(event)
+
+    except Exception as e:
+        entry = {
+                "severity": "WARNING",
+                "msg": "Data not saved to BigQuery",
+                "errors": str(e),
+                "json_payload": envelope
+            }
+        print(json.dumps(entry))
+
+    return "", 204
+
+
+def process_cloud_build_event(attr, msg):
+    event_type = "build"
+    e_id = attr["buildId"]
+
+    # Unique hash for the event
+    signature = shared.create_unique_id(msg)
+
+    # Payload
+    metadata = json.loads(base64.b64decode(msg["data"]).decode("utf-8").strip())
+
+    # Most up to date timestamp for the event
+    time_created = (metadata.get("finishTime") or metadata.get("startTime") or metadata.get("createTime"))
+
+    build_event = {
+        "event_type": event_type,
+        "id": e_id,
+        "metadata": json.dumps(metadata),
+        "time_created": time_created,
+        "signature": signature,
+        "msg_id": msg["message_id"],
+        "source": "cloud_build",
+    }
+
+    return build_event
+
+
+if __name__ == "__main__":
+    PORT = int(os.getenv("PORT")) if os.getenv("PORT") else 8080
+
+    # This is used when running locally. Gunicorn is used to run the
+    # application on Cloud Run. See entrypoint in Dockerfile.
+    app.run(host="127.0.0.1", port=PORT, debug=True)

--- a/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/main_test.py
+++ b/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/main_test.py
@@ -1,1 +1,89 @@
-../../../../../../../bq-workers/cloud-build-parser/main_test.py
+# Copyright 2020 Google, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import json
+
+import main
+import shared
+
+import mock
+import pytest
+
+
+@pytest.fixture
+def client():
+    main.app.testing = True
+    return main.app.test_client()
+
+
+def test_not_json(client):
+    with pytest.raises(Exception) as e:
+        client.post("/", data="foo")
+
+    assert "Expecting JSON payload" in str(e.value)
+
+
+def test_not_pubsub_message(client):
+    with pytest.raises(Exception) as e:
+        client.post(
+            "/",
+            data=json.dumps({"foo": "bar"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert "Not a valid Pub/Sub Message" in str(e.value)
+
+
+def test_missing_msg_attributes(client):
+    with pytest.raises(Exception) as e:
+        client.post(
+            "/",
+            data=json.dumps({"message": "bar"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert "Missing pubsub attributes" in str(e.value)
+
+
+def test_cloud_build_event_processed(client):
+    data = json.dumps({"createTime": 1, "startTime": 2, "finishTime": 3}).encode("utf-8")
+    pubsub_msg = {
+        "message": {
+            "data": base64.b64encode(data).decode("utf-8"),
+            "attributes": {"buildId": "foo"},
+            "message_id": "foobar",
+        },
+    }
+
+    build_event = {
+        "event_type": "build",
+        "id": "foo",
+        "metadata": '{"createTime": 1, "startTime": 2, "finishTime": 3}',
+        "time_created": 3,
+        "signature": shared.create_unique_id(pubsub_msg["message"]),
+        "msg_id": "foobar",
+        "source": "cloud_build",
+    }
+
+    shared.insert_row_into_bigquery = mock.MagicMock()
+
+    r = client.post(
+        "/",
+        data=json.dumps(pubsub_msg),
+        headers={"Content-Type": "application/json"},
+    )
+
+    shared.insert_row_into_bigquery.assert_called_with(build_event)
+    assert r.status_code == 204

--- a/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/requirements-test.txt
+++ b/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/requirements-test.txt
@@ -1,1 +1,2 @@
-../../../../../../../bq-workers/cloud-build-parser/requirements-test.txt
+-r requirements.txt
+pytest~=6.0.0

--- a/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/requirements.txt
+++ b/experimental/terraform/modules/fourkeys-images/files/bq-workers/cloud-build-parser/requirements.txt
@@ -1,1 +1,4 @@
-../../../../../../../bq-workers/cloud-build-parser/requirements.txt
+Flask==2.0.3
+gunicorn==19.9.0
+google-cloud-bigquery==1.23.1
+git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared

--- a/experimental/terraform/modules/fourkeys-images/main.tf
+++ b/experimental/terraform/modules/fourkeys-images/main.tf
@@ -5,6 +5,7 @@ locals {
 }
 
 resource "google_project_service" "images_services" {
+  project                    = var.project_id
   for_each                   = toset(local.services)
   service                    = each.value
   disable_on_destroy         = false

--- a/experimental/terraform/modules/fourkeys-images/main.tf
+++ b/experimental/terraform/modules/fourkeys-images/main.tf
@@ -19,9 +19,6 @@ module "gcloud_build_dashboard" {
   create_cmd_body        = "builds submit ${path.module}/files/dashboard --tag=gcr.io/${var.project_id}/fourkeys-grafana-dashboard --project=${var.project_id}"
   destroy_cmd_entrypoint = "gcloud"
   destroy_cmd_body       = "container images delete gcr.io/${var.project_id}/fourkeys-grafana-dashboard --quiet"
-  depends_on = [
-    google_project_service.images_services
-  ]
 }
 
 module "gcloud_build_data_source" {
@@ -34,9 +31,6 @@ module "gcloud_build_data_source" {
   create_cmd_body        = "builds submit ${path.module}/files/bq-workers/${each.value}-parser --tag=gcr.io/${var.project_id}/${each.value}-parser --project=${var.project_id}"
   destroy_cmd_entrypoint = "gcloud"
   destroy_cmd_body       = "container images delete gcr.io/${var.project_id}/${each.value}-parser --quiet"
-  depends_on = [
-    google_project_service.images_services
-  ]
 }
 
 module "gcloud_build_event_handler" {
@@ -46,7 +40,4 @@ module "gcloud_build_event_handler" {
   create_cmd_body        = "builds submit ${path.module}/files/event_handler --tag=gcr.io/${var.project_id}/event-handler --project=${var.project_id}"
   destroy_cmd_entrypoint = "gcloud"
   destroy_cmd_body       = "container images delete gcr.io/${var.project_id}/event-handler --quiet"
-  depends_on = [
-    google_project_service.images_services
-  ]
 }

--- a/experimental/terraform/modules/fourkeys-tekton-parser/main.tf
+++ b/experimental/terraform/modules/fourkeys-tekton-parser/main.tf
@@ -1,0 +1,77 @@
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+locals {
+    services = var.enable_apis ? [
+    "run.googleapis.com"
+  ] : []
+}
+
+resource "google_project_service" "data_source_services" {
+  project                    = var.project_id
+  for_each                   = toset(local.services)
+  service                    = each.value
+  disable_on_destroy         = false
+}
+
+resource "google_cloud_run_service" "tekton_parser" {
+  project  = var.project_id
+  name     = "fourkeys-tekton-parser"
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = var.parser_container_url
+        env {
+          name  = "PROJECT_NAME"
+          value = var.project_id
+        }
+      }
+      service_account_name = var.fourkeys_service_account_email
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  autogenerate_revision_name = true
+  depends_on = [
+    google_project_service.data_source_services
+  ]
+}
+
+resource "google_pubsub_topic" "tekton" {
+  project = var.project_id
+  name    = "fourkeys-tekton"
+}
+
+resource "google_pubsub_topic_iam_member" "service_account_editor" {
+  project = var.project_id
+  topic   = google_pubsub_topic.tekton.id
+  role    = "roles/editor"
+  member  = "serviceAccount:${var.fourkeys_service_account_email}"
+}
+
+resource "google_pubsub_subscription" "tekton" {
+  project = var.project_id
+  name    = "fourkeys-tekton"
+  topic   = google_pubsub_topic.tekton.id
+
+  push_config {
+    push_endpoint = google_cloud_run_service.tekton_parser.status[0]["url"]
+
+    oidc_token {
+      service_account_email = var.fourkeys_service_account_email
+    }
+  }
+}
+
+resource "google_project_iam_member" "pubsub_service_account_token_creator" {
+  project = var.project_id
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+  role    = "roles/iam.serviceAccountTokenCreator"
+}

--- a/experimental/terraform/modules/fourkeys-tekton-parser/variables.tf
+++ b/experimental/terraform/modules/fourkeys-tekton-parser/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  type = string
+  description = "Project ID of the target project."
+}
+
+variable "region" {
+  type    = string
+  description = "Region to deploy resources."
+  default = "us-central1"
+}
+
+variable "fourkeys_service_account_email" {
+  type = string
+  description = "Service account for fourkeys."
+}
+
+variable "enable_apis" {
+  type        = bool
+  description = "Toggle to include required APIs."
+  default     = false
+}
+
+variable "parser_container_url" {
+  type = string
+  description = "URL of image to use in Cloud Run service configuration."
+}

--- a/experimental/terraform/modules/fourkeys/main.tf
+++ b/experimental/terraform/modules/fourkeys/main.tf
@@ -89,6 +89,19 @@ module "tekton_parser" {
   ]
 }
 
+module "cloud_build_parser" {
+  source = "../fourkeys-cloud-build-parser"
+  count = contains(var.parsers, "cloud-build") ? 1 : 0
+  project_id  = var.project_id
+  parser_container_url = local.parser_container_urls["cloud-build"]
+  region  = var.region
+  fourkeys_service_account_email = module.foundation.fourkeys_service_account_email
+  enable_apis                    = var.enable_apis
+  depends_on = [
+    module.fourkeys_images
+  ]
+}
+
 module "dashboard" {
   source                         = "../fourkeys-dashboard"
   project_id                     = var.project_id

--- a/experimental/terraform/modules/fourkeys/main.tf
+++ b/experimental/terraform/modules/fourkeys/main.tf
@@ -61,12 +61,24 @@ module "bigquery" {
 }
 
 module "github_parser" {
-  source                         = "../fourkeys-data-source"
-  for_each                       = toset(var.parsers)
-  project_id                     = var.project_id
-  parser_service_name            = each.value
-  parser_container_url           = local.parser_container_urls[each.value]
-  region                         = var.region
+  source = "../fourkeys-github-parser"
+  count = contains(var.parsers, "github") ? 1 : 0
+  project_id  = var.project_id
+  parser_container_url = local.parser_container_urls["github"]
+  region  = var.region
+  fourkeys_service_account_email = module.foundation.fourkeys_service_account_email
+  enable_apis                    = var.enable_apis
+  depends_on = [
+    module.fourkeys_images
+  ]
+}
+
+module "gitlab_parser" {
+  source = "../fourkeys-gitlab-parser"
+  count = contains(var.parsers, "gitlab") ? 1 : 0
+  project_id  = var.project_id
+  parser_container_url = local.parser_container_urls["gitlab"]
+  region  = var.region
   fourkeys_service_account_email = module.foundation.fourkeys_service_account_email
   enable_apis                    = var.enable_apis
   depends_on = [

--- a/experimental/terraform/modules/fourkeys/main.tf
+++ b/experimental/terraform/modules/fourkeys/main.tf
@@ -1,7 +1,3 @@
-data "google_project" "project" {
-  project_id = var.project_id
-}
-
 locals {
   event_handler_container_url = var.enable_build_images ? format("gcr.io/%s/event-handler", var.project_id) : var.event_handler_container_url
   dashboard_container_url     = var.enable_build_images ? format("gcr.io/%s/fourkeys-grafana-dashboard", var.project_id) : var.dashboard_container_url
@@ -19,12 +15,6 @@ module "fourkeys_images" {
   project_id  = var.project_id
   enable_apis = var.enable_apis
   parsers     = var.parsers
-}
-
-resource "google_project_iam_member" "pubsub_service_account_token_creator" {
-  project = var.project_id
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-  role    = "roles/iam.serviceAccountTokenCreator"
 }
 
 module "foundation" {

--- a/experimental/terraform/modules/fourkeys/main.tf
+++ b/experimental/terraform/modules/fourkeys/main.tf
@@ -76,6 +76,19 @@ module "gitlab_parser" {
   ]
 }
 
+module "tekton_parser" {
+  source = "../fourkeys-tekton-parser"
+  count = contains(var.parsers, "tekton") ? 1 : 0
+  project_id  = var.project_id
+  parser_container_url = local.parser_container_urls["tekton"]
+  region  = var.region
+  fourkeys_service_account_email = module.foundation.fourkeys_service_account_email
+  enable_apis                    = var.enable_apis
+  depends_on = [
+    module.fourkeys_images
+  ]
+}
+
 module "dashboard" {
   source                         = "../fourkeys-dashboard"
   project_id                     = var.project_id

--- a/experimental/terraform/modules/fourkeys/main.tf
+++ b/experimental/terraform/modules/fourkeys/main.tf
@@ -1,3 +1,7 @@
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
 locals {
   event_handler_container_url = var.enable_build_images ? format("gcr.io/%s/event-handler", var.project_id) : var.event_handler_container_url
   dashboard_container_url     = var.enable_build_images ? format("gcr.io/%s/fourkeys-grafana-dashboard", var.project_id) : var.dashboard_container_url
@@ -15,6 +19,12 @@ module "fourkeys_images" {
   project_id  = var.project_id
   enable_apis = var.enable_apis
   parsers     = var.parsers
+}
+
+resource "google_project_iam_member" "pubsub_service_account_token_creator" {
+  project = var.project_id
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+  role    = "roles/iam.serviceAccountTokenCreator"
 }
 
 module "foundation" {


### PR DESCRIPTION
Instead of one module that creates all parsers, each parser is now in its own isolated module for readability and independent deployment.