### PR TITLE
Use SHA256 instead of SHA1 for GitHub's signature verification

### DIFF
--- a/event_handler/event_handler_test.py
+++ b/event_handler/event_handler_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import hmac
-from hashlib import sha1
+from hashlib import sha256
 
 import event_handler
 
@@ -60,7 +60,7 @@ def test_unverified_signature(client):
     "event_handler.publish_to_pubsub", mock.MagicMock(return_value=True)
 )
 def test_verified_signature(client):
-    signature = "sha1=" + hmac.new(b"foo", b"Hello", sha1).hexdigest()
+    signature = "sha256=" + hmac.new(b"foo", b"Hello", sha256).hexdigest()
     r = client.post(
         "/",
         data="Hello",
@@ -71,7 +71,7 @@ def test_verified_signature(client):
 
 @mock.patch("sources.get_secret", mock.MagicMock(return_value=b"foo"))
 def test_data_sent_to_pubsub(client):
-    signature = "sha1=" + hmac.new(b"foo", b"Hello", sha1).hexdigest()
+    signature = "sha256=" + hmac.new(b"foo", b"Hello", sha256).hexdigest()
     event_handler.publish_to_pubsub = mock.MagicMock(return_value=True)
     headers = {
         "User-Agent": "GitHub-Hookshot",

--- a/event_handler/sources.py
+++ b/event_handler/sources.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import hmac
-from hashlib import sha1
+from hashlib import sha256
 import os
 
 from google.cloud import secretmanager
@@ -38,12 +38,12 @@ def github_verification(signature, body):
     if not signature:
         raise Exception("Github signature is empty")
 
-    expected_signature = "sha1="
+    expected_signature = "sha256="
     try:
         # Get secret from Cloud Secret Manager
         secret = get_secret(PROJECT_NAME, "event-handler", "latest")
         # Compute the hashed signature
-        hashed = hmac.new(secret, body, sha1)
+        hashed = hmac.new(secret, body, sha256)
         expected_signature += hashed.hexdigest()
 
     except Exception as e:
@@ -120,7 +120,7 @@ def get_source(headers):
 
 AUTHORIZED_SOURCES = {
     "github": EventSource(
-        "X-Hub-Signature", github_verification
+        "X-Hub-Signature-256", github_verification
         ),
     "gitlab": EventSource(
         "X-Gitlab-Token", simple_token_verification


### PR DESCRIPTION
## Description
Use `X-Hub-Signature-256` header instead of `X-Hub-Signature`.
This is because the document contained the following information.

> X-Hub-Signature is provided for compatibility with existing integrations, and we recommend that you use the more secure X-Hub-Signature-256 instead.
-- https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads