### PR TITLE
throw exception when event_type is push and the field deleted is true

### DIFF
--- a/bq-workers/github-parser/main.py
+++ b/bq-workers/github-parser/main.py
@@ -87,6 +87,8 @@ def process_github_event(headers, msg):
     metadata = json.loads(base64.b64decode(msg["data"]).decode("utf-8").strip())
 
     if event_type == "push":
+        if metadata["deleted"]:
+            raise Exception("Unsupported GitHub event: '%s' when deleted is true" % event_type)
         time_created = metadata["head_commit"]["timestamp"]
         e_id = metadata["head_commit"]["id"]
 


### PR DESCRIPTION
GitHub sends two events when refs are deleted.
One is Delete event and another is Push event the field `deleted`  of which payload is true. And the field `head_commit` of Push events payloads is null.

So, we see `Unsupported GitHub event: 'delete'` and `'NoneType' object is not subscriptable` messages when git refs are deleted, and I think the latter message is a little surprising.
I added a change to check whether the `deleted` field is true and skips parsing logic if true.