### PR TITLE
Add Sentry as supported incident system. 

### DIFF
--- a/bq-workers/sentry-parser/Dockerfile
+++ b/bq-workers/sentry-parser/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Use the official Python image.
+# https://hub.docker.com/_/python
+FROM python:3.10
+
+# Allow statements and log messages to immediately appear in the Cloud Run logs
+ENV PYTHONUNBUFFERED True
+
+# Copy application dependency manifests to the container image.
+# Copying this separately prevents re-running pip install on every code change.
+COPY requirements.txt .
+
+# Install production dependencies.
+RUN pip install -r requirements.txt
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . .
+
+# Run the web service on container startup.
+# Use gunicorn webserver with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/bq-workers/sentry-parser/cloudbuild.yaml
+++ b/bq-workers/sentry-parser/cloudbuild.yaml
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- # Build sentry-parser image
+  name: gcr.io/cloud-builders/docker:latest
+  args: ['build', 
+         '--tag=gcr.io/$PROJECT_ID/sentry-parser:${_TAG}', '.']
+  id: build
+
+- # Push the container image to Artifact Registry
+  name: gcr.io/cloud-builders/docker
+  args: ['push', 'gcr.io/$PROJECT_ID/sentry-parser:${_TAG}']
+  waitFor: build
+  id: push
+
+- # Deploy to Cloud Run
+  name: google/cloud-sdk
+  args: ['gcloud', 'run', 'deploy', 'sentry-parser',
+         '--image', 'gcr.io/$PROJECT_ID/sentry-parser:${_TAG}',
+         '--region', '${_REGION}',
+         '--platform', 'managed'
+  ]
+  id: deploy
+  waitFor: push
+
+images: [
+  'gcr.io/$PROJECT_ID/sentry-parser:${_TAG}'
+]

--- a/bq-workers/sentry-parser/main.py
+++ b/bq-workers/sentry-parser/main.py
@@ -1,0 +1,93 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import os
+import json
+
+import shared
+
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+@app.route("/", methods=["POST"])
+def index():
+    """
+    Receives messages from a push subscription from Pub/Sub.
+    Parses the message, and inserts it into BigQuery.
+    """
+    event = None
+    # Check request for JSON
+    if not request.is_json:
+        raise Exception("Expecting JSON payload")
+    envelope = request.get_json()
+
+    # Check that message is a valid pub/sub message
+    if "message" not in envelope:
+        raise Exception("Not a valid Pub/Sub Message")
+    msg = envelope["message"]
+
+    if "attributes" not in msg:
+        raise Exception("Missing pubsub attributes")
+
+    try:
+        attr = msg["attributes"]
+
+        if "headers" in attr:
+            headers = json.loads(attr["headers"])
+
+            if "Sentry-Hook-Resource" in headers:
+                event = process_sentry_event(headers, msg)
+
+        shared.insert_row_into_bigquery(event)
+
+    except Exception as e:
+        entry = {
+            "severity": "WARNING",
+            "msg": "Data not saved to BigQuery",
+            "errors": str(e),
+            "json_payload": envelope
+        }
+        print(json.dumps(entry))
+
+    return "", 204
+
+
+def process_sentry_event(headers, msg):
+    event_type = headers["Sentry-Hook-Resource"]
+    metadata = json.loads(base64.b64decode(msg["data"]).decode("utf-8").strip())
+    types = {"issue"}
+
+    if event_type not in types:
+        raise Exception("Unsupported Sentry event: '%s'" % event_type)
+
+    return {
+        "event_type": event_type,
+        "id": metadata["data"]["issue"]["id"],
+        "metadata": json.dumps(metadata),
+        "time_created": headers["Sentry-Hook-Timestamp"],
+        "signature": headers["Sentry-Hook-Signature"],
+        "msg_id": msg["message_id"],
+        "source": "sentry",
+    }
+
+
+if __name__ == "__main__":
+    PORT = int(os.getenv("PORT")) if os.getenv("PORT") else 8080
+
+    # This is used when running locally. Gunicorn is used to run the
+    # application on Cloud Run. See entrypoint in Dockerfile.
+    app.run(host="127.0.0.1", port=PORT, debug=True)

--- a/bq-workers/sentry-parser/main_test.py
+++ b/bq-workers/sentry-parser/main_test.py
@@ -119,7 +119,7 @@ def test_sentry_event_processed(client):
                     "Content-Type": "application/json",
                     "Request-ID": "ef0dd634-e830-4aa4-a690-5fca54a11a18",
                     "Sentry-Hook-Resource": "issue",
-                    "Sentry-Hook-Timestamp": "2022-03-06T11:31:64.118160Z",
+                    "Sentry-Hook-Timestamp": "2022-06-20 12:49:49 UTC",
                     "Sentry-Hook-Signature": "<generated_signature>"
                 })
             },
@@ -131,7 +131,7 @@ def test_sentry_event_processed(client):
         "event_type": "issue",
         "id": "3359227809",
         "metadata": data.decode("utf-8"),
-        "time_created": "2022-03-06T11:31:64.118160Z",
+        "time_created": "2022-06-20 12:49:49 UTC",
         "signature": "<generated_signature>",
         "msg_id": "foobar",
         "source": "sentry",
@@ -170,7 +170,7 @@ def test_unsupported_sentry_event_processed(client):
                     "Content-Type": "application/json",
                     "Request-ID": "ef0dd634-e830-4aa4-a690-5fca54a11a18",
                     "Sentry-Hook-Resource": "comment",
-                    "Sentry-Hook-Timestamp": "2022-03-06T11:31:64.118160Z",
+                    "Sentry-Hook-Timestamp": "2022-06-20 12:49:49 UTC",
                     "Sentry-Hook-Signature": "<generated_signature>"
                 })
             },

--- a/bq-workers/sentry-parser/main_test.py
+++ b/bq-workers/sentry-parser/main_test.py
@@ -1,0 +1,190 @@
+# Copyright 2020 Google, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import json
+
+import main
+import shared
+
+import mock
+import pytest
+
+
+@pytest.fixture
+def client():
+    main.app.testing = True
+    return main.app.test_client()
+
+
+def test_not_json(client):
+    with pytest.raises(Exception) as e:
+        client.post("/", data="foo")
+
+    assert "Expecting JSON payload" in str(e.value)
+
+
+def test_not_pubsub_message(client):
+    with pytest.raises(Exception) as e:
+        client.post(
+            "/",
+            data=json.dumps({"foo": "bar"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert "Not a valid Pub/Sub Message" in str(e.value)
+
+
+def test_missing_msg_attributes(client):
+    with pytest.raises(Exception) as e:
+        client.post(
+            "/",
+            data=json.dumps({"message": "bar"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert "Missing pubsub attributes" in str(e.value)
+
+
+def test_sentry_event_processed(client):
+    data = json.dumps({
+        "action": "created",
+        "installation": {
+            "uuid": "95cc9015-1456-4656-83fb-df3fa930348e"
+        },
+        "data": {
+            "issue": {
+                "id": "3359227809",
+                "shareId": None,
+                "shortId": "PROJECT-NAME",
+                "title": "Your exception: Cannot continue.",
+                "culprit": "com.google.common.base.Preconditions in checkState",
+                "permalink": None,
+                "logger": "com.logger.name",
+                "level": "warning",
+                "status": "unresolved",
+                "statusDetails": {},
+                "isPublic": False,
+                "platform": "rust",
+                "project": {
+                    "id": "5303212330",
+                    "name": "name",
+                    "slug": "name",
+                    "platform": "rust"
+                },
+                "type": "error",
+                "metadata": {
+                    "value": "Cannot continue.",
+                    "type": "YourException",
+                    "filename": "Preconditions.java",
+                    "function": "checkState",
+                    "display_title_with_tree_label": False
+                },
+                "numComments": 0,
+                "assignedTo": None,
+                "isBookmarked": False,
+                "isSubscribed": False,
+                "subscriptionDetails": None,
+                "hasSeen": False,
+                "annotations": [],
+                "isUnhandled": False,
+                "count": "1",
+                "userCount": 0,
+                "firstSeen": "2022-06-01T00:50:02.780000Z",
+                "lastSeen": "2022-06-18T13:50:02.780000Z"
+            }
+        },
+        "actor": {
+            "type": "application",
+            "id": "sentry",
+            "name": "Sentry"
+        }
+    }).encode("utf-8")
+    pubsub_msg = {
+        "message": {
+            "data": base64.b64encode(data).decode("utf-8"),
+            "attributes": {
+                "headers": json.dumps({
+                    "Content-Type": "application/json",
+                    "Request-ID": "ef0dd634-e830-4aa4-a690-5fca54a11a18",
+                    "Sentry-Hook-Resource": "issue",
+                    "Sentry-Hook-Timestamp": "2022-03-06T11:31:64.118160Z",
+                    "Sentry-Hook-Signature": "<generated_signature>"
+                })
+            },
+            "message_id": "foobar",
+        },
+    }
+
+    event = {
+        "event_type": "issue",
+        "id": "3359227809",
+        "metadata": data.decode("utf-8"),
+        "time_created": "2022-03-06T11:31:64.118160Z",
+        "signature": "<generated_signature>",
+        "msg_id": "foobar",
+        "source": "sentry",
+    }
+
+    shared.insert_row_into_bigquery = mock.MagicMock()
+
+    r = client.post(
+        "/",
+        data=json.dumps(pubsub_msg),
+        headers={"Content-Type": "application/json"},
+    )
+
+    shared.insert_row_into_bigquery.assert_called_with(event)
+    assert r.status_code == 204
+
+
+def test_unsupported_sentry_event_processed(client):
+    data = json.dumps({
+        "action": "created",
+        "data": {
+            "comment": "adding a comment",
+            "project_slug": "sentry",
+            "comment_id": 1234,
+            "issue_id": 100,
+            "timestamp": "2022-03-02T21:51:44.118160Z"
+        },
+        "installation": {"uuid": "eac5a0ae-60ec-418f-9318-46dc5e7e52ec"},
+        "actor": {"type": "user", "id": 1, "name": "Rikkert"}
+    }).encode("utf-8")
+    pubsub_msg = {
+        "message": {
+            "data": base64.b64encode(data).decode("utf-8"),
+            "attributes": {
+                "headers": json.dumps({
+                    "Content-Type": "application/json",
+                    "Request-ID": "ef0dd634-e830-4aa4-a690-5fca54a11a18",
+                    "Sentry-Hook-Resource": "comment",
+                    "Sentry-Hook-Timestamp": "2022-03-06T11:31:64.118160Z",
+                    "Sentry-Hook-Signature": "<generated_signature>"
+                })
+            },
+            "message_id": "foobar",
+        },
+    }
+
+    shared.insert_row_into_bigquery = mock.MagicMock()
+
+    r = client.post(
+        "/",
+        data=json.dumps(pubsub_msg),
+        headers={"Content-Type": "application/json"},
+    )
+
+    shared.insert_row_into_bigquery.assert_not_called()
+    assert r.status_code == 204

--- a/bq-workers/sentry-parser/requirements-test.txt
+++ b/bq-workers/sentry-parser/requirements-test.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==7.1.2

--- a/bq-workers/sentry-parser/requirements.txt
+++ b/bq-workers/sentry-parser/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.1.2
+gunicorn==20.1.0
+google-cloud-bigquery==3.2.0
+git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared

--- a/event_handler/Dockerfile
+++ b/event_handler/Dockerfile
@@ -15,7 +15,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7-slim
+FROM python:3.10-slim
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/event_handler/event_handler.py
+++ b/event_handler/event_handler.py
@@ -37,7 +37,7 @@ def index():
     source = sources.get_source(request.headers)
 
     if source not in sources.AUTHORIZED_SOURCES:
-        print("Source not authorized", source)
+        print(f"Source [{source}] not authorized")
         abort(403, f"Source not authorized: {source}")
 
     auth_source = sources.AUTHORIZED_SOURCES[source]
@@ -45,7 +45,7 @@ def index():
     signature = signature_sources.get(auth_source.signature, None)
 
     if not signature:
-        print("Signature not found in request headers", auth_source.signature)
+        print(f"Signature [{auth_source.signature}] not found in request headers")
         abort(403, "Signature not found in request headers")
 
     body = request.data
@@ -53,7 +53,7 @@ def index():
     # Verify the signature
     verify_signature = auth_source.verification
     if not verify_signature(signature, body):
-        print("Signature does not match expected signature", source)
+        print(f"Signature given by [{source}] does not match expected signature")
         abort(403, "Signature does not match expected signature")
 
     # Remove the Auth header so we do not publish it to Pub/Sub

--- a/event_handler/requirements-test.txt
+++ b/event_handler/requirements-test.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-pytest~=6.0.0
+pytest==7.1.2

--- a/event_handler/requirements.txt
+++ b/event_handler/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.0.3
-gunicorn==19.9.0
-google-cloud-pubsub==1.1.0
-google-cloud-secret-manager==0.1.0
+Flask==2.1.2
+gunicorn==20.1.0
+google-cloud-pubsub==2.13.0
+google-cloud-secret-manager==2.11.1

--- a/event_handler/sources.py
+++ b/event_handler/sources.py
@@ -128,7 +128,7 @@ def simple_token_verification(token, body):
     return secret.decode() == token
 
 
-def get_secret(secret_name, secret_version = "latest"):
+def get_secret(secret_name, secret_version="latest"):
     """
     Returns secret payload from Cloud Secret Manager
     """

--- a/queries/incidents.sql
+++ b/queries/incidents.sql
@@ -13,19 +13,23 @@ CASE WHEN source LIKE "github%" THEN JSON_EXTRACT_SCALAR(metadata, '$.issue.numb
      WHEN source LIKE "gitlab%" AND event_type = "note" THEN JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.noteable_id')
      WHEN source LIKE "gitlab%" AND event_type = "issue" THEN JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.id')
      WHEN source LIKE "pagerduty%" THEN JSON_EXTRACT_SCALAR(metadata, '$.event.data.id')
+     WHEN source LIKE "sentry%" AND event_type = "issue" THEN id
      END AS incident_id,
 CASE WHEN source LIKE "github%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.issue.created_at'))
      WHEN source LIKE "gitlab%" THEN four_keys.multiFormatParseTimestamp(JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.created_at'))
      WHEN source LIKE "pagerduty%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.event.occurred_at'))
+     WHEN source LIKE "sentry%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.data.issue.firstSeen'))
      END AS time_created,
 CASE WHEN source LIKE "github%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.issue.closed_at'))
      WHEN source LIKE "gitlab%" THEN four_keys.multiFormatParseTimestamp(JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.closed_at'))
      WHEN source LIKE "pagerduty%" THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.event.occurred_at'))
+     WHEN source LIKE "sentry%" AND JSON_EXTRACT_SCALAR(metadata, '$.data.issue.status') = 'resolved' THEN TIMESTAMP(JSON_EXTRACT_SCALAR(metadata, '$.data.issue.lastSeen'))
      END AS time_resolved,
 REGEXP_EXTRACT(metadata, r"root cause: ([[:alnum:]]*)") as root_cause,
 CASE WHEN source LIKE "github%" THEN REGEXP_CONTAINS(JSON_EXTRACT(metadata, '$.issue.labels'), '"name":"Incident"')
      WHEN source LIKE "gitlab%" THEN REGEXP_CONTAINS(JSON_EXTRACT(metadata, '$.object_attributes.labels'), '"title":"Incident"')
      WHEN source LIKE "pagerduty%" THEN TRUE # All Pager Duty events are incident-related
+     WHEN source LIKE "sentry%" THEN JSON_EXTRACT_SCALAR(metadata, '$.data.issue.level') IN ('error', 'fatal')
      END AS bug,
 FROM four_keys.events_raw 
 WHERE event_type LIKE "issue%" OR event_type LIKE "incident%" OR (event_type = "note" and JSON_EXTRACT_SCALAR(metadata, '$.object_attributes.noteable_type') = 'Issue')

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -30,7 +30,7 @@
     # google_project_id (FOURKEYS_PROJECT)
     # google_region (FOURKEYS_REGION)
     # bigquery_region (BIGQUERY_REGION)
-    # parsers [(list of VCS and CICD parsers to install)]
+    # parsers [(list of data parsers to install)]
 
 set -eEuo pipefail
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -67,7 +67,8 @@ else
     read -p "
     Which incident management system(s) are you using? 
     (1) PagerDuty
-    (2) Other
+    (2) Sentry
+    (3) Other
 
     Enter a selection (1 - 2): " incident_system_id
 
@@ -88,7 +89,7 @@ printf "\n"
 GIT_SYSTEM=""
 CICD_SYSTEM=""
 INCIDENT_SYSTEM=""
-PAGERDUTY_SECRET=""
+INCIDENT_SYSTEM_SECRET=""
 
 case $git_system_id in
     1) GIT_SYSTEM="gitlab" ;;
@@ -105,12 +106,13 @@ case $cicd_system_id in
 esac
 
 case $incident_system_id in
-    1) INCIDENT_SYSTEM="pagerduty"; read -p "Please enter the PagerDuty Signature Verification Token: " PAGERDUTY_SECRET ;;
+    1) INCIDENT_SYSTEM="pagerduty"; read -p "Please enter the PagerDuty Signature Verification Token: " INCIDENT_SYSTEM_SECRET ;;
+    2) INCIDENT_SYSTEM="sentry"; read -p "Please enter the Sentry Client Secret: " INCIDENT_SYSTEM_SECRET ;;
     *) echo "Please see the documentation to learn how to extend to incident sources other than PagerDuty."
 esac
 
-if [ $PAGERDUTY_SECRET != "" ]; then
-    echo $PAGERDUTY_SECRET | tr -d '\n' | gcloud secrets create pager_duty_secret \
+if [ $INCIDENT_SYSTEM_TOKEN != "" ]; then
+    echo $INCIDENT_SYSTEM_SECRET | tr -d '\n' | gcloud secrets create ${INCIDENT_SYSTEM}_secret \
     --replication-policy=user-managed --locations ${FOURKEYS_REGION} \
     --data-file=-
 fi


### PR DESCRIPTION
This adds support for [Sentry](https://sentry.io/) error tracking as incident input.
Not sure if this needs more documentation in the readme.
The bug clause for sentry in incidents.sql probably needs tweaking / use case but this seems like an ok starting point.
The metadata doesn't include any kind of commit sha or release information atm. Not sure how to make this count in the failed deployments graph without this info.