### PR TITLE
Use latest image for  cloud run

### DIFF
--- a/setup/dashboard/main.tf
+++ b/setup/dashboard/main.tf
@@ -8,7 +8,7 @@ resource "google_cloud_run_service" "dashboard" {
         ports {
           container_port = 3000
         }
-        image = "gcr.io/${var.google_project_id}/fourkeys-grafana-dashboard"
+        image = "gcr.io/${var.google_project_id}/fourkeys-grafana-dashboard:latest"
         env {
           name  = "PROJECT_NAME"
           value = var.google_project_id

--- a/setup/data_parser/main.tf
+++ b/setup/data_parser/main.tf
@@ -5,7 +5,7 @@ resource "google_cloud_run_service" "parser" {
   template {
     spec {
       containers {
-        image = "gcr.io/${var.google_project_id}/${var.parser_service_name}-parser"
+        image = "gcr.io/${var.google_project_id}/${var.parser_service_name}-parser:latest"
         env {
           name  = "PROJECT_NAME"
           value = var.google_project_id

--- a/setup/resource_event_handler.tf
+++ b/setup/resource_event_handler.tf
@@ -9,7 +9,7 @@ resource "google_cloud_run_service" "event_handler" {
   template {
     spec {
       containers {
-        image = "gcr.io/${var.google_project_id}/event-handler"
+        image = "gcr.io/${var.google_project_id}/event-handler:latest"
         env {
           name  = "PROJECT_NAME"
           value = var.google_project_id


### PR DESCRIPTION
For now,  docker images of gcr are updated by `gcloud builds submit` of `install.sh` every time setup.sh is called. But, deployed images of cloud run  are NOT updated.
I know I can rebuild and deploy the container  by `gcloud builds submit` with `cloudbuild.yaml` manually, but I think it is better  to control using terraform.