### PR TITLE
Add new variable for fourkeys-images terraform module

### DIFF
--- a/terraform/modules/fourkeys-images/main.tf
+++ b/terraform/modules/fourkeys-images/main.tf
@@ -17,7 +17,7 @@ module "gcloud_build_dashboard" {
   platform               = "linux"
   additional_components  = []
   create_cmd_entrypoint  = "gcloud"
-  create_cmd_body        = "builds submit ${path.module}/files/dashboard --tag=${var.registry_hostname}/${var.project_id}/fourkeys-grafana-dashboard --project=${var.project_id}"
+  create_cmd_body        = "builds submit ${path.module}/files/dashboard --tag=${var.registry_hostname}/${var.project_id}/fourkeys-grafana-dashboard --project=${var.project_id} ${var.gcloud_builds_extra_arguments}"
   destroy_cmd_entrypoint = "gcloud"
   destroy_cmd_body       = "container images delete ${var.registry_hostname}/${var.project_id}/fourkeys-grafana-dashboard --quiet"
 }
@@ -29,7 +29,7 @@ module "gcloud_build_data_source" {
   platform               = "linux"
   additional_components  = []
   create_cmd_entrypoint  = "gcloud"
-  create_cmd_body        = "builds submit ${path.module}/files/bq-workers/${each.value}-parser --tag=${var.registry_hostname}/${var.project_id}/${each.value}-parser --project=${var.project_id}"
+  create_cmd_body        = "builds submit ${path.module}/files/bq-workers/${each.value}-parser --tag=${var.registry_hostname}/${var.project_id}/${each.value}-parser --project=${var.project_id} ${var.gcloud_builds_extra_arguments}"
   destroy_cmd_entrypoint = "gcloud"
   destroy_cmd_body       = "container images delete ${var.registry_hostname}/${var.project_id}/${each.value}-parser --quiet"
 }
@@ -38,7 +38,7 @@ module "gcloud_build_event_handler" {
   source                 = "terraform-google-modules/gcloud/google"
   version                = "~> 2.0"
   create_cmd_entrypoint  = "gcloud"
-  create_cmd_body        = "builds submit ${path.module}/files/event-handler --tag=${var.registry_hostname}/${var.project_id}/event-handler --project=${var.project_id}"
+  create_cmd_body        = "builds submit ${path.module}/files/event-handler --tag=${var.registry_hostname}/${var.project_id}/event-handler --project=${var.project_id} ${var.gcloud_builds_extra_arguments}"
   destroy_cmd_entrypoint = "gcloud"
   destroy_cmd_body       = "container images delete ${var.registry_hostname}/${var.project_id}/event-handler --quiet"
 }

--- a/terraform/modules/fourkeys-images/main.tf
+++ b/terraform/modules/fourkeys-images/main.tf
@@ -17,9 +17,9 @@ module "gcloud_build_dashboard" {
   platform               = "linux"
   additional_components  = []
   create_cmd_entrypoint  = "gcloud"
-  create_cmd_body        = "builds submit ${path.module}/files/dashboard --tag=gcr.io/${var.project_id}/fourkeys-grafana-dashboard --project=${var.project_id}"
+  create_cmd_body        = "builds submit ${path.module}/files/dashboard --tag=${var.registry_hostname}/${var.project_id}/fourkeys-grafana-dashboard --project=${var.project_id}"
   destroy_cmd_entrypoint = "gcloud"
-  destroy_cmd_body       = "container images delete gcr.io/${var.project_id}/fourkeys-grafana-dashboard --quiet"
+  destroy_cmd_body       = "container images delete ${var.registry_hostname}/${var.project_id}/fourkeys-grafana-dashboard --quiet"
 }
 
 module "gcloud_build_data_source" {
@@ -29,16 +29,16 @@ module "gcloud_build_data_source" {
   platform               = "linux"
   additional_components  = []
   create_cmd_entrypoint  = "gcloud"
-  create_cmd_body        = "builds submit ${path.module}/files/bq-workers/${each.value}-parser --tag=gcr.io/${var.project_id}/${each.value}-parser --project=${var.project_id}"
+  create_cmd_body        = "builds submit ${path.module}/files/bq-workers/${each.value}-parser --tag=${var.registry_hostname}/${var.project_id}/${each.value}-parser --project=${var.project_id}"
   destroy_cmd_entrypoint = "gcloud"
-  destroy_cmd_body       = "container images delete gcr.io/${var.project_id}/${each.value}-parser --quiet"
+  destroy_cmd_body       = "container images delete ${var.registry_hostname}/${var.project_id}/${each.value}-parser --quiet"
 }
 
 module "gcloud_build_event_handler" {
   source                 = "terraform-google-modules/gcloud/google"
   version                = "~> 2.0"
   create_cmd_entrypoint  = "gcloud"
-  create_cmd_body        = "builds submit ${path.module}/files/event-handler --tag=gcr.io/${var.project_id}/event-handler --project=${var.project_id}"
+  create_cmd_body        = "builds submit ${path.module}/files/event-handler --tag=${var.registry_hostname}/${var.project_id}/event-handler --project=${var.project_id}"
   destroy_cmd_entrypoint = "gcloud"
-  destroy_cmd_body       = "container images delete gcr.io/${var.project_id}/event-handler --quiet"
+  destroy_cmd_body       = "container images delete ${var.registry_hostname}/${var.project_id}/event-handler --quiet"
 }

--- a/terraform/modules/fourkeys-images/variables.tf
+++ b/terraform/modules/fourkeys-images/variables.tf
@@ -18,3 +18,9 @@ variable "registry_hostname" {
   description = "Define registry hostname"
   default     = "gcr.io"
 }
+
+variable "gcloud_builds_extra_arguments" {
+  type        = string
+  description = "Set extra arguments for gcloud builds command"
+  default     = ""
+}

--- a/terraform/modules/fourkeys-images/variables.tf
+++ b/terraform/modules/fourkeys-images/variables.tf
@@ -12,3 +12,9 @@ variable "parsers" {
   type        = list(string)
   description = "List of data parsers to configure. Acceptable values are: 'github', 'gitlab', 'cloud-build', 'tekton'"
 }
+
+variable "registry_hostname" {
+  type        = string
+  description = "Define registry hostname"
+  default     = "gcr.io"
+}


### PR DESCRIPTION
Added a `registry_hostname` variable to be able to use a registry from a different region and `gcloud_builds_extra_arguments` to set extra arguments for the build image. 

The extra argument is necessary in my case to set a `--gcs-log-dir` argument to use a different log bucket once by default the terraform user needs Editor or Viewer access to be able to follow the logs.

