### PR TITLE
Feat/add events enriched to generate data

### DIFF
--- a/data-generator/generate_data.py
+++ b/data-generator/generate_data.py
@@ -249,7 +249,7 @@ if __name__ == "__main__":
         # It is git for a sha/commit that doesn't exist
         prev_change_sha = "0000000000000000000000000000000000000000"
         # Send individual changes data
-        for i, c in enumerate(changeset["commits"]):
+        for c in changeset["commits"]:
             curr_change = None
             if args.vc_system == "gitlab":
                 curr_change = {

--- a/data-generator/generate_data.py
+++ b/data-generator/generate_data.py
@@ -192,7 +192,7 @@ if __name__ == "__main__":
         "--num_events",
         "-e",
         type=int,
-        default=20,
+        default=40,
         help="number of events to generate; default=20",
     )
     parser.add_argument(

--- a/data-generator/generate_data.py
+++ b/data-generator/generate_data.py
@@ -232,9 +232,10 @@ if __name__ == "__main__":
             args.vc_system,
             args.event_timespan,
         )
+        changeset["before"] = secrets.token_hex(20) if x == 0 else all_changesets[x-1]["checkout_sha"]
 
         # Send individual changes data
-        for c in changeset["commits"]:
+        for i, c in enumerate(changeset["commits"]):
             curr_change = None
             if args.vc_system == "gitlab":
                 curr_change = {
@@ -244,6 +245,7 @@ if __name__ == "__main__":
                 }
             if args.vc_system == "github":
                 curr_change = {"head_commit": c, "commits": [c]}
+            curr_change["before"] = "0000000000000000000000000000000000000000" if i == 0 else changeset["commits"][i-1]["id"]
             changes_sent += post_to_webhook(
                 args.vc_system, webhook_url, secret, "push", curr_change, token
             )

--- a/data-generator/generate_data.py
+++ b/data-generator/generate_data.py
@@ -162,16 +162,15 @@ def make_webhook_request(vcs, webhook_url, secret, event_type, data, token=None)
 
 
 def post_to_webhook(vcs, webhook_url, secret, event_type, data, token=None):
-    return 1
 
-    # request = make_webhook_request(vcs, webhook_url, secret, event_type, data, token)
-    #
-    # response = urlopen(request)
-    #
-    # if response.getcode() == 204:
-    #     return 1
-    # else:
-    #     return 0
+    request = make_webhook_request(vcs, webhook_url, secret, event_type, data, token)
+
+    response = urlopen(request)
+
+    if response.getcode() == 204:
+        return 1
+    else:
+        return 0
 
 
 if __name__ == "__main__":
@@ -217,11 +216,11 @@ if __name__ == "__main__":
     secret = os.environ.get("SECRET")
     token = os.environ.get("TOKEN")
 
-    # if not webhook_url or not secret:
-    #     print(
-    #         "Error: please ensure the following environment variables are set: WEBHOOK, SECRET"
-    #     )
-    #     sys.exit()
+    if not webhook_url or not secret:
+        print(
+            "Error: please ensure the following environment variables are set: WEBHOOK, SECRET"
+        )
+        sys.exit()
 
     all_changesets = []
     changes_sent = 0

--- a/data-generator/generate_data.py
+++ b/data-generator/generate_data.py
@@ -250,7 +250,7 @@ if __name__ == "__main__":
                 curr_change = {"head_commit": c, "commits": [c]}
 
             # We only post individual commits with shas not matching the changeset sha
-            if prev_change_sha != changeset_sha:
+            if c["id"] != changeset_sha:
                 curr_change["before"] = prev_change_sha
                 prev_change_sha = c["id"]
 


### PR DESCRIPTION
# Summary

With the goal of creating mock data that can have multiple branches be linked to a single commit for the purpose of testing the up coming feature (discussed here: https://github.com/GoogleCloudPlatform/fourkeys/issues/52) to do just that, modified `generate_data.py` to include the data that is sent by GH and GL that allows tracking commits backwards.

## Added
- [Add before key to generate_data.py generated commits](https://github.com/GoogleCloudPlatform/fourkeys/commit/60599dae8e00255ba654547af117326d24d29bf4)

## Changed
- [Prevent generate_data from generating multiple gitlab deploy events with same deploy id](https://github.com/GoogleCloudPlatform/fourkeys/commit/8d92b8d5967b6e4219e6e5eda5ba028fb7a61825)
- [Add it so the generate_data only send deployments for changesets half the time, so that a single deployment can have multiple changesets/branches](https://github.com/GoogleCloudPlatform/fourkeys/commit/a409ce5e21ced0259413757133706097ab1857e7)
- [Increase generate_data def num_events by factor of 2 because now only 1/2 create deployments](https://github.com/GoogleCloudPlatform/fourkeys/commit/6b2f277a04fdf8530debd6dcab4321cae5c3ff5d)
- [Refactor `generate_data.py` to pull a lot of the if __name__ == "__main__":
stuff into functions that can be tested.](https://github.com/GoogleCloudPlatform/fourkeys/pull/363/commits/489c7507b9c72c57f41a0143fad92b0dc870029d)
- [Make tests that test whether the "before" attribute of the previous sha was
set properly](https://github.com/GoogleCloudPlatform/fourkeys/pull/363/commits/489c7507b9c72c57f41a0143fad92b0dc870029d)