### PR TITLE
Generate mock only in case of GitLab or GitHub

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -47,7 +47,7 @@ else
     read -p "Enter the region for Four Keys resources (ex: 'us-central1'): " FOURKEYS_REGION
     read -p "Enter the location for Four Keys BigQuery resources ('US' or 'EU'): " BIGQUERY_REGION
 
-    read -p "Which version control system are you using? 
+    read -p "Which version control system are you using?
     (1) GitLab
     (2) GitHub
     (3) Other
@@ -55,7 +55,7 @@ else
     Enter a selection (1 - 3): " git_system_id
 
     read -p "
-    Which CI/CD system are you using? 
+    Which CI/CD system are you using?
     (1) Cloud Build
     (2) Tekton
     (3) GitLab
@@ -66,7 +66,7 @@ else
     Enter a selection (1 - 6): " cicd_system_id
 
     read -p "
-    Which incident management system(s) are you using? 
+    Which incident management system(s) are you using?
     (1) PagerDuty
     (2) Other
 
@@ -74,8 +74,14 @@ else
 
     printf "\n"
 
-    read -p "Would you like to generate mock data? (y/N): " generate_mock_data
-    generate_mock_data=${generate_mock_data:-no}
+    if [[ ${git_system_id} == "1" ]] || [[ ${git_system_id} == "2" ]]
+    then
+        read -p "Would you like to generate mock data? (y/N): " generate_mock_data
+        generate_mock_data=${generate_mock_data:-no}
+    else
+        # offer mock data only in case of GitLab or GitHub
+        generate_mock_data="N"
+    fi
 fi
 
 if [[ ${CLEAN} == 'true' ]]


### PR DESCRIPTION
Hi, there is an error during installation
```
••••••••🔑••🔑••🔑••🔑••••••••
generating data…
usage: generate_data.py [-h] [--event_timespan EVENT_TIMESPAN]
						[--num_events NUM_EVENTS] [--num_issues NUM_ISSUES]
						--vc_system {gitlab,github}
generate_data.py: error: argument --vc_system/-v: invalid choice: '' (choose from 'gitlab', 'github')

Script done on 2022-10-03 14:38:02+00:00 [COMMAND_EXIT_CODE="2"]
```
in case user has chosen "Other" in VCS question
```
Which version control system are you using? 
    (1) GitLab
    (2) GitHub
    (3) Other

    Enter a selection (1 - 3): 3
```

This PR adds a simple check if generation is possible.