### PR TITLE
Add-expirantion_policy

### DIFF
--- a/terraform/modules/fourkeys-gitlab-parser/main.tf
+++ b/terraform/modules/fourkeys-gitlab-parser/main.tf
@@ -60,6 +60,10 @@ resource "google_pubsub_subscription" "gitlab" {
   project = var.project_id
   name    = "gitlab"
   topic   = google_pubsub_topic.gitlab.id
+  
+  expiration_policy {
+    ttl = ""
+  }
 
   push_config {
     push_endpoint = google_cloud_run_service.gitlab_parser.status[0]["url"]


### PR DESCRIPTION
Added `expirantion_policy` to pub/sub subscription to not delete due to inactivity.
[Doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription#expiration_policy)