### PR TITLE
Set-secret-manager-only-region

### DIFF
--- a/terraform/modules/fourkeys/event-handler.tf
+++ b/terraform/modules/fourkeys/event-handler.tf
@@ -40,8 +40,11 @@ resource "google_secret_manager_secret" "event_handler" {
   project   = var.project_id
   secret_id = "event-handler"
   replication {
-    automatic = true
-  }
+    user_managed {
+      replicas {
+        location = var.region
+      }
+    }
   depends_on = [
     time_sleep.wait_for_services
   ]


### PR DESCRIPTION
With `replication {  automatic = true  }` it is not controllable where the secret will be created, as throughout the project we use a specified zone, I believe this change is valid

[DOC](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret#nested_user_managed)