### PR TITLE
Add-backend-terraform

### DIFF
--- a/terraform/example/main.tf
+++ b/terraform/example/main.tf
@@ -1,8 +1,8 @@
 module "fourkeys" {
-  source              = "../modules/fourkeys"
-  project_id          = var.project_id
-  enable_apis         = var.enable_apis
-  region              = var.region
-  bigquery_region     = var.bigquery_region
-  parsers             = var.parsers
+  source          = "../modules/fourkeys"
+  project_id      = var.project_id
+  enable_apis     = var.enable_apis
+  region          = var.region
+  bigquery_region = var.bigquery_region
+  parsers         = var.parsers
 }

--- a/terraform/modules/fourkeys-backend-terraform/README.md
+++ b/terraform/modules/fourkeys-backend-terraform/README.md
@@ -1,0 +1,17 @@
+
+
+## Using tfsate remote
+
+Add the code snippet below in the [file](https://github.com/GoogleCloudPlatform/fourkeys/blob/main/terraform/example/main.tf), enabling the sending of 'remote tfstate' to GCP.
+
+```
+terraform {
+  backend "gcs" {
+    bucket = "[project-id]-bucket-tfstate"
+    prefix = "terraform/state"
+  }
+}
+```
+
+
+In the `google_storage_bucket` is used variable `uniform_bucket_level_access` [doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket#uniform_bucket_level_access)

--- a/terraform/modules/fourkeys-backend-terraform/main.tf
+++ b/terraform/modules/fourkeys-backend-terraform/main.tf
@@ -1,0 +1,34 @@
+locals {
+  project_id                  = var.project_id
+  location_storage            = var.location_storage
+  uniform_bucket_level_access = var.uniform_bucket_level_access
+}
+
+
+resource "google_project_service" "fourkeys-backend-terraform" {
+  project = local.project_id
+  service = "storage.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = true
+}
+
+
+resource "google_storage_bucket" "fourkeys-backend-terraform" {
+  name                        = "${local.project_id}-bucket-tfstate"
+  force_destroy               = false
+  location                    = local.location_storage
+  project                     = local.project_id
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = local.uniform_bucket_level_access
+  versioning {
+    enabled = true
+  }
+  depends_on = [
+    google_project_service.fourkeys-backend-terraform
+  ]
+}

--- a/terraform/modules/fourkeys-backend-terraform/provider.tf
+++ b/terraform/modules/fourkeys-backend-terraform/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.17.0"
+    }
+  }
+}

--- a/terraform/modules/fourkeys-backend-terraform/terraform.tfvars.example
+++ b/terraform/modules/fourkeys-backend-terraform/terraform.tfvars.example
@@ -1,0 +1,3 @@
+project_id = "<PROJECT_ID>"
+uniform_bucket_level_access = "true|False"
+location_storage = "<REGION>"

--- a/terraform/modules/fourkeys-backend-terraform/variable.tf
+++ b/terraform/modules/fourkeys-backend-terraform/variable.tf
@@ -1,0 +1,20 @@
+variable "project_id" {
+  type        = string
+  description = "project to deploy four keys resources to"
+}
+
+variable "uniform_bucket_level_access" {
+  type        = bool
+  default     = true
+  description = "Enables Uniform bucket-level access access to a bucket"
+}
+
+variable "location_storage" {
+  type        = string
+  default     = "US"
+  description = "Region to deploy storage resources in."
+  validation {
+    condition     = can(regex("^(US|EU)$", var.location_storage))
+    error_message = "The value for 'location_storage' must be one of: 'US','EU'."
+  }
+}


### PR DESCRIPTION
Hi,

A module was created to create and configure the 'bucket' that will be the 'backend' of terraforme.

Before being a PR that can be accepted, it is still necessary to improve the README of the module, and the README that explains how to run terraform.
I believe that with this documentation it can already be understood, anything I am available to try better.

This PR intends to address the [issue](https://github.com/GoogleCloudPlatform/fourkeys/issues/412).